### PR TITLE
Issue syslib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ run-tests.php
 /build
 /include
 /modules
+ltmain.sh.backup
+tmp-php.ini

--- a/tests/008.phpt
+++ b/tests/008.phpt
@@ -30,28 +30,28 @@ check_compress($data, 0);
 *** Data size ***
 3547
 *** Compression Level ***
-1 -- 1874 -- true
-2 -- 1847 -- true
-3 -- 1840 -- true
-4 -- 1815 -- true
-5 -- 1805 -- true
-6 -- 1803 -- true
-7 -- 1803 -- true
-8 -- 1803 -- true
-9 -- 1803 -- true
-10 -- 1803 -- true
-11 -- 1800 -- true
-12 -- 1796 -- true
-13 -- 1796 -- true
-14 -- 1796 -- true
-15 -- 1796 -- true
-16 -- 1796 -- true
-17 -- 1796 -- true
-18 -- 1796 -- true
-19 -- 1796 -- true
-20 -- 1796 -- true
-21 -- 1796 -- true
-22 -- 1796 -- true
+1 -- 1%d -- true
+2 -- 1%d -- true
+3 -- 1%d -- true
+4 -- 1%d -- true
+5 -- 1%d -- true
+6 -- 1%d -- true
+7 -- 1%d -- true
+8 -- 1%d -- true
+9 -- 1%d -- true
+10 -- 1%d -- true
+11 -- 1%d -- true
+12 -- 1%d -- true
+13 -- 1%d -- true
+14 -- 1%d -- true
+15 -- 1%d -- true
+16 -- 1%d -- true
+17 -- 1%d -- true
+18 -- 1%d -- true
+19 -- 1%d -- true
+20 -- 1%d -- true
+21 -- 1%d -- true
+22 -- 1%d -- true
 *** Invalid Compression Level ***
 
 Warning: zstd_compress: compression level (100) must be within 1..22 in %s on line %d

--- a/tests/dictionary.phpt
+++ b/tests/dictionary.phpt
@@ -24,5 +24,5 @@ check_compress_dict($data, $dictionary);
 *** Data size ***
 3547
 *** Dictionary Compression ***
-142 -- 1924 -- true
+142 -- 1%d -- true
 ===Done===

--- a/zstd.c
+++ b/zstd.c
@@ -294,7 +294,6 @@ ZEND_FUNCTION(zstd_uncompress_dict)
 
 ZEND_MINFO_FUNCTION(zstd)
 {
-    char buffer[128];
     php_info_print_table_start();
     php_info_print_table_row(2, "Zstd support", "enabled");
     php_info_print_table_row(2, "Extension Version", PHP_ZSTD_EXT_VERSION);


### PR DESCRIPTION
Tested with libzstd 1.3.3 (in Fedora / EPEL repository)

    Tests passed    :   11 (100.0%) (100.0%)

I only implement library search using pkg-config, which IMHO is the cleanest way.