### PR TITLE
Minor typo in config.m4

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -25,7 +25,7 @@ PHP_ARG_ENABLE(zstd, whether to enable zstd support,
 [  --enable-zstd           Enable zstd support])
 
 PHP_ARG_WITH(libzstd, whether to use system zstd library,
-[  --with-libzsd           Use system zstd library], no, no)
+[  --with-libzstd           Use system zstd library], no, no)
 
 if test "$PHP_ZSTD" != "no"; then
 


### PR DESCRIPTION
Typo in description for configure option `--with-libzstd`.