### PR TITLE
Fixed memory allocation bug on stream decompress

### DIFF
--- a/zstd.c
+++ b/zstd.c
@@ -198,8 +198,9 @@ ZEND_FUNCTION(zstd_uncompress)
 
         while (in.pos < in.size) {
             if (out.pos == out.size) {
-                out.dst = erealloc(out.dst, size);
                 out.size += size;
+                output = erealloc(output, out.size);
+                out.dst = output;
             }
 
             result = ZSTD_decompressStream(stream, &out, &in);


### PR DESCRIPTION
- First problem was that **erealloc** function second parameter must be new size for the memory block not difference.

- If **erealloc** relocates memory to new place then we need that **out.dst** and **output** variables show to same new memory place.