### PR TITLE
Upgrade libzstd to 1.4.0

### DIFF
--- a/tests/001.phpt
+++ b/tests/001.phpt
@@ -30,9 +30,9 @@ var_dump(bin2hex(zstd_compress($smallstring) ));
 
 ?>
 ===Done===
---EXPECT--
+--EXPECTF--
 *** Compression ***
-string(32) "2852da3dd89b79ac8654def609f4af7c"
+string(32) "%s"
 bool(true)
 *** Compression ***
 string(72) "28b52ffd201bd900004120736d616c6c20737472696e6720746f20636f6d70726573730a"

--- a/tests/003.phpt
+++ b/tests/003.phpt
@@ -15,6 +15,6 @@ var_dump(md5(zstd_compress($output)));
 ===Done===
 --EXPECTF--
 *** Testing multiple compression ***
-string(32) "2852da3dd89b79ac8654def609f4af7c"
-string(32) "68cc81622d0e2e6b6b795fdc5c61bf54"
+string(32) "%s"
+string(32) "%s"
 ===Done===

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -31,9 +31,9 @@ var_dump(bin2hex(\Zstd\compress($smallstring) ));
 
 ?>
 ===Done===
---EXPECT--
+--EXPECTF--
 *** Compression ***
-string(32) "2852da3dd89b79ac8654def609f4af7c"
+string(32) "%s"
 bool(true)
 *** Compression ***
 string(72) "28b52ffd201bd900004120736d616c6c20737472696e6720746f20636f6d70726573730a"

--- a/tests/streams_1.phpt
+++ b/tests/streams_1.phpt
@@ -24,7 +24,7 @@ $ctx = stream_context_create(
 
 var_dump(file_put_contents('compress.zstd://' . $file, $data, 0, $ctx) == strlen($data));
 var_dump($size2 = filesize($file));
-var_dump($size1 > 1 && $size2 <= $size1);
+var_dump($size2 > 1 && $size2 <= $size1);
 
 
 echo "Decompression\n";

--- a/tests/streams_5.phpt
+++ b/tests/streams_5.phpt
@@ -1,0 +1,44 @@
+--TEST--
+compress.zstd streams with dictionary
+--SKIPIF--
+<?php
+if (LIBZSTD_VERSION_NUMBER < 10400) die("skip needs libzstd 1.4.0");
+?>
+--FILE--
+<?php
+include(dirname(__FILE__) . '/data.inc');
+
+$file = dirname(__FILE__) . '/data.out';
+$dictionary = file_get_contents(dirname(__FILE__) . '/data.dic');
+
+echo "Compression\n";
+
+$ctx = stream_context_create(
+	array(
+		"zstd" => array(
+			"level" => ZSTD_COMPRESS_LEVEL_DEFAULT,
+			"dict"  => $dictionary,
+		)
+	)
+);
+
+var_dump(file_put_contents('compress.zstd://' . $file, $data, 0, $ctx) == strlen($data));
+var_dump($size1 = filesize($file));
+var_dump($size1 > 1 && $size1 < strlen($data));
+
+echo "Decompression\n";
+
+$decomp = file_get_contents('compress.zstd://' . $file, false, $ctx);
+var_dump($decomp == $data);
+
+@unlink($file);
+?>
+===Done===
+--EXPECTF--
+Compression
+bool(true)
+int(%d)
+bool(true)
+Decompression
+bool(true)
+===Done===

--- a/zstd.c
+++ b/zstd.c
@@ -630,6 +630,11 @@ php_stream_zstd_opener(
 {
     php_zstd_stream_data *self;
     int level = ZSTD_CLEVEL_DEFAULT;
+    int compress;
+#if ZSTD_VERSION_NUMBER >= 10400
+    ZSTD_CDict *cdict = NULL;
+    ZSTD_DDict *ddict = NULL;
+#endif
 
     if (strncasecmp(STREAM_NAME, path, sizeof(STREAM_NAME)-1) == 0) {
         path += sizeof(STREAM_NAME)-1;
@@ -642,13 +647,34 @@ php_stream_zstd_opener(
         return NULL;
     }
 
+    if (!strcmp(mode, "w") || !strcmp(mode, "wb")) {
+       compress = 1;
+    } else if (!strcmp(mode, "r") || !strcmp(mode, "rb")) {
+       compress = 0;
+    } else {
+        php_error_docref(NULL TSRMLS_CC, E_ERROR, "zstd: invalid open mode");
+        return NULL;
+    }
+
     if (context) {
 #if PHP_MAJOR_VERSION >= 7
         zval *tmpzval;
+        zend_string *data;
 
         if (NULL != (tmpzval = php_stream_context_get_option(context, "zstd", "level"))) {
             level = zval_get_long(tmpzval);
         }
+#if ZSTD_VERSION_NUMBER >= 10400
+        if (NULL != (tmpzval = php_stream_context_get_option(context, "zstd", "dict"))) {
+            data = zval_get_string(tmpzval);
+            if (compress) {
+                cdict = ZSTD_createCDict(ZSTR_VAL(data), ZSTR_LEN(data), level);
+            } else {
+                ddict = ZSTD_createDDict(ZSTR_VAL(data), ZSTR_LEN(data));
+            }
+            zend_string_release(data);
+        }
+#endif
 #else
         zval **tmpzval;
 
@@ -656,6 +682,16 @@ php_stream_zstd_opener(
             convert_to_long_ex(tmpzval);
             level = Z_LVAL_PP(tmpzval);
         }
+#if ZSTD_VERSION_NUMBER >= 10400
+        if (php_stream_context_get_option(context, "zstd", "dict", &tmpzval) == SUCCESS) {
+            convert_to_string(*tmpzval);
+            if (compress) {
+                cdict = ZSTD_createCDict(Z_STRVAL_PP(tmpzval), Z_STRLEN_PP(tmpzval), level);
+            } else {
+                ddict = ZSTD_createDDict(Z_STRVAL_PP(tmpzval), Z_STRLEN_PP(tmpzval));
+            }
+        }
+#endif
 #endif
     }
 
@@ -667,7 +703,7 @@ php_stream_zstd_opener(
     self = ecalloc(sizeof(*self), 1);
     self->stream = php_stream_open_wrapper(path, mode, REPORT_ERRORS, NULL);
     /* File */
-    if (!strcmp(mode, "w") || !strcmp(mode, "wb")) {
+    if (compress) {
         self->dctx = NULL;
         self->cctx = ZSTD_createCCtx();
         if (!self->cctx) {
@@ -678,7 +714,7 @@ php_stream_zstd_opener(
         }
 #if ZSTD_VERSION_NUMBER >= 10400
         ZSTD_CCtx_reset(self->cctx, ZSTD_reset_session_only);
-        ZSTD_CCtx_refCDict(self->cctx, NULL);
+        ZSTD_CCtx_refCDict(self->cctx, cdict);
         ZSTD_CCtx_setParameter(self->cctx, ZSTD_c_compressionLevel, level);
 #else
         ZSTD_initCStream(self->cctx, level);
@@ -694,7 +730,7 @@ php_stream_zstd_opener(
 
         return php_stream_alloc(&php_stream_zstd_write_ops, self, NULL, mode);
 
-    } else if (!strcmp(mode, "r") || !strcmp(mode, "rb")) {
+    } else {
         self->dctx = ZSTD_createDCtx();
         if (!self->dctx) {
             php_error_docref(NULL TSRMLS_CC, E_WARNING, "zstd: compression context failed");
@@ -707,7 +743,7 @@ php_stream_zstd_opener(
         self->bufout = emalloc(self->sizeout = ZSTD_DStreamOutSize());
 #if ZSTD_VERSION_NUMBER >= 10400
         ZSTD_DCtx_reset(self->dctx, ZSTD_reset_session_only);
-        ZSTD_DCtx_refDDict(self->dctx, NULL);
+        ZSTD_DCtx_refDDict(self->dctx, ddict);
 #else
         ZSTD_initDStream(self->dctx);
 #endif
@@ -719,9 +755,6 @@ php_stream_zstd_opener(
         self->output.size = 0;
 
         return php_stream_alloc(&php_stream_zstd_read_ops, self, NULL, mode);
-
-    } else {
-        php_error_docref(NULL TSRMLS_CC, E_ERROR, "zstd: invalid open mode");
     }
     return NULL;
 }
@@ -761,6 +794,13 @@ ZEND_MINIT_FUNCTION(zstd)
                            CONST_CS | CONST_PERSISTENT);
     REGISTER_LONG_CONSTANT("ZSTD_COMPRESS_LEVEL_DEFAULT",
                            DEFAULT_COMPRESS_LEVEL,
+                           CONST_CS | CONST_PERSISTENT);
+
+    REGISTER_LONG_CONSTANT("LIBZSTD_VERSION_NUMBER",
+                           ZSTD_VERSION_NUMBER,
+                           CONST_CS | CONST_PERSISTENT);
+    REGISTER_STRING_CONSTANT("LIBZSTD_VERSION_STRING",
+                           ZSTD_VERSION_STRING,
                            CONST_CS | CONST_PERSISTENT);
 
     php_register_url_stream_wrapper(STREAM_NAME, &php_stream_zstd_wrapper TSRMLS_CC);


### PR DESCRIPTION
Also, relax tests as compressed data may differ in various `libzstd` versions

TODO: check which parameters can be set via the PHP context as `ZSTD_CCtx_setParameter` is now available in stable API

+ pass "dict" via context

+ expose LIBZSTD_VERSION_NUMBER and LIBZSTD_VERSION_STRING, mostly for skip condition in tests.