### PR TITLE
fix for stream changes in 7.4.0beta1

### DIFF
--- a/zstd.c
+++ b/zstd.c
@@ -488,9 +488,16 @@ static int php_zstd_comp_close(php_stream *stream, int close_handle TSRMLS_DC)
 }
 
 
+#if PHP_VERSION_ID < 70400
 static size_t php_zstd_decomp_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)
 {
-    size_t x, res, ret = 0;
+    size_t ret = 0;
+#else
+static ssize_t php_zstd_decomp_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)
+{
+    ssize_t ret = 0;
+#endif
+    size_t x, res;
     STREAM_DATA_FROM_STREAM();
 
     while (count > 0) {
@@ -536,9 +543,16 @@ static size_t php_zstd_decomp_read(php_stream *stream, char *buf, size_t count T
 }
 
 
+#if PHP_VERSION_ID < 70400
 static size_t php_zstd_comp_write(php_stream *stream, const char *buf, size_t count TSRMLS_DC)
 {
-    size_t res, x, ret = 0;
+    size_t ret = 0;
+#else
+static ssize_t php_zstd_comp_write(php_stream *stream, const char *buf, size_t count TSRMLS_DC)
+{
+    ssize_t ret = 0;
+#endif
+    size_t x, res;
 
     STREAM_DATA_FROM_STREAM();
 

--- a/zstd.c
+++ b/zstd.c
@@ -525,6 +525,9 @@ static ssize_t php_zstd_decomp_read(php_stream *stream, char *buf, size_t count 
             res = ZSTD_decompressStream(self->dctx, &self->output , &self->input);
             if (ZSTD_isError(res)) {
                 php_error_docref(NULL TSRMLS_CC, E_WARNING, "libzstd error %s\n", ZSTD_getErrorName(res));
+#if PHP_VERSION_ID >= 70400
+                return -1;
+#endif
             }
             /* for us */
             self->output.size = self->output.pos;
@@ -586,6 +589,9 @@ static ssize_t php_zstd_comp_write(php_stream *stream, const char *buf, size_t c
 #endif
             if (ZSTD_isError(res)) {
                 php_error_docref(NULL TSRMLS_CC, E_WARNING, "libzstd error %s\n", ZSTD_getErrorName(res));
+#if PHP_VERSION_ID >= 70400
+                return -1;
+#endif
             }
             php_stream_write(self->stream, self->bufout, self->output.pos);
         } while (self->input.pos != self->input.size);


### PR DESCRIPTION
From UPGRADING.INTERNALS
```
  y. The read and write operations of php_stream_ops now return ssize_t, with
     negative values indicating an error.

```
Notice: 7.4.0beta1 will be announced Thursday 25th
