### PR TITLE
Test streams_7.phpt sould be skippable for offline

### DIFF
--- a/tests/streams_7.phpt
+++ b/tests/streams_7.phpt
@@ -3,6 +3,7 @@ compress.zstd read online stream denied
 --SKIPIF--
 <?php
 if (version_compare(PHP_VERSION, '5.4', '<')) die('skip PHP is too old');
+if (getenv("SKIP_ONLINE_TESTS")) die('skip online test');
 ?>
 --INI--
 allow_url_fopen=0


### PR DESCRIPTION
This test require HTTPS but no way to skip it like `streams_6.phpt`