### PR TITLE
ztsd_uncompress may return a empty string

### DIFF
--- a/tests/001.phpt
+++ b/tests/001.phpt
@@ -13,13 +13,13 @@ $smallstring = "A small string to compress\n";
 $level = 1;
 
 // Compressing a big string
-echo "*** Compression ***", PHP_EOL;
+echo "*** Compression big ***", PHP_EOL;
 $output = zstd_compress($data, $level);
 var_dump(md5($output));
 var_dump(zstd_uncompress($output) === $data);
 
 // Compressing a smaller string
-echo "*** Compression ***", PHP_EOL;
+echo "*** Compression small ***", PHP_EOL;
 $output = zstd_compress($smallstring, $level);
 var_dump(bin2hex($output));
 var_dump(zstd_uncompress($output) === $smallstring);
@@ -28,15 +28,23 @@ var_dump(zstd_uncompress($output) === $smallstring);
 echo "*** Testing with no specified compression ***", PHP_EOL;
 var_dump(bin2hex(zstd_compress($smallstring) ));
 
+// Compressing a empty string
+echo "*** Compression empty ***", PHP_EOL;
+$output = zstd_compress('', $level);
+var_dump(bin2hex($output));
+var_dump(zstd_uncompress($output) === '');
 ?>
 ===Done===
 --EXPECTF--
-*** Compression ***
+*** Compression big ***
 string(32) "%s"
 bool(true)
-*** Compression ***
+*** Compression small ***
 string(72) "28b52ffd201bd900004120736d616c6c20737472696e6720746f20636f6d70726573730a"
 bool(true)
 *** Testing with no specified compression ***
 string(72) "28b52ffd201bd900004120736d616c6c20737472696e6720746f20636f6d70726573730a"
+*** Compression empty ***
+string(18) "28b52ffd2000010000"
+bool(true)
 ===Done===

--- a/zstd.c
+++ b/zstd.c
@@ -224,7 +224,7 @@ ZEND_FUNCTION(zstd_uncompress)
 
     if (ZSTD_isError(result)) {
         RETVAL_FALSE;
-    } else if (result <= 0) {
+    } else if (result < 0) {
         RETVAL_FALSE;
     } else {
 #if ZEND_MODULE_API_NO >= 20141001


### PR DESCRIPTION
With current version
```
$ php -r 'var_dump(zstd_uncompress(zstd_compress("")));'
bool(false)
```

With this fix
```
$ php -n -d extension=modules/zstd.so  -r 'var_dump(zstd_uncompress(zstd_compress("")));'
string(0) ""
```

From ZSTD_compress doc:
` *   note 1 : a 0 return value means the frame is valid but "empty".`
