### PR TITLE
Requires ext-openssl for opening https streams

### DIFF
--- a/tests/streams_6.phpt
+++ b/tests/streams_6.phpt
@@ -4,6 +4,7 @@ compress.zstd read online stream
 <?php
 if (version_compare(PHP_VERSION, '5.4', '<')) die('skip PHP is too old');
 if (getenv("SKIP_ONLINE_TESTS")) die('skip online test');
+if (!extension_loaded('openssl')) die('skip reqiures ext-openssl for https stream');
 ?>
 --INI--
 allow_url_fopen=1


### PR DESCRIPTION
http://buildlogs.pld-linux.org//index.php?dist=th&arch=x86_64&ok=0&name=php-pecl-zstd&id=2c8bc259-054c-4501-bf1e-286acde23cff&action=tail:

```
========DIFF========
001+ Warning: readfile(): Unable to find the wrapper "https" - did you forget to enable it when you configured PHP? in /tmp/B.gASoNX/BUILD/php74-pecl-zstd-0.8.0/tests/streams_6.php on line 2
002+
003+ Warning: readfile(https://github.com/kjdev/php-ext-zstd/raw/master/tests/streaming.zst): failed to open stream: No such file or directory in /tmp/B.gASoNX/BUILD/php74-pecl-zstd-0.8.0/tests/streams_6.php on line 2
004+
005+ Warning: readfile(compress.zstd://https://github.com/kjdev/php-ext-zstd/raw/master/tests/streaming.zst): failed to open stream: operation failed in /tmp/B.gASoNX/BUILD/php74-pecl-zstd-0.8.0/tests/streams_6.php on line 2
006+
001- X
========DONE========
```

refs:
- https://github.com/pld-linux/php-pecl-zstd/commit/b2a796013e3edb1660a662c72f448b0c704f5df1