### PR TITLE
Tests: Fix confused too old/new message

### DIFF
--- a/tests/002.phpt
+++ b/tests/002.phpt
@@ -2,7 +2,7 @@
 zstd_compress(): error conditions
 --SKIPIF--
 <?php
-if (version_compare(PHP_VERSION, '8.0', '>=')) die('skip PHP is too old');
+if (version_compare(PHP_VERSION, '8.0', '>=')) die('skip PHP is too new');
 --FILE--
 <?php
 include(dirname(__FILE__) . '/data.inc');

--- a/tests/002.phpt
+++ b/tests/002.phpt
@@ -2,7 +2,7 @@
 zstd_compress(): error conditions
 --SKIPIF--
 <?php
-if (version_compare(PHP_VERSION, '8.0', '>=')) die('skip PHP is too new');
+if (PHP_VERSION_ID >= 80000) die("skip requires PHP <8.0");
 --FILE--
 <?php
 include(dirname(__FILE__) . '/data.inc');

--- a/tests/002_b.phpt
+++ b/tests/002_b.phpt
@@ -2,7 +2,7 @@
 zstd_compress(): error conditions
 --SKIPIF--
 <?php
-if (version_compare(PHP_VERSION, '8.0', '<')) die('skip PHP is too new');
+if (version_compare(PHP_VERSION, '8.0', '<')) die('skip PHP is too old');
 --FILE--
 <?php
 include(dirname(__FILE__) . '/data.inc');

--- a/tests/002_b.phpt
+++ b/tests/002_b.phpt
@@ -2,7 +2,7 @@
 zstd_compress(): error conditions
 --SKIPIF--
 <?php
-if (version_compare(PHP_VERSION, '8.0', '<')) die('skip PHP is too old');
+if (PHP_VERSION_ID < 80000) die("skip requires PHP 8.0+");
 --FILE--
 <?php
 include(dirname(__FILE__) . '/data.inc');

--- a/tests/005.phpt
+++ b/tests/005.phpt
@@ -2,7 +2,7 @@
 zstd_uncompress(): error conditions
 --SKIPIF--
 <?php
-if (version_compare(PHP_VERSION, '8.0', '>=')) die('skip PHP is too old');
+if (PHP_VERSION_ID >= 80000) die("skip requires PHP < 8.0");
 --FILE--
 <?php
 

--- a/tests/005_b.phpt
+++ b/tests/005_b.phpt
@@ -2,7 +2,7 @@
 zstd_uncompress(): error conditions
 --SKIPIF--
 <?php
-if (version_compare(PHP_VERSION, '8.0', '<')) die('skip PHP is too new');
+if (PHP_VERSION_ID < 80000) die("skip requires PHP 8.0+");
 --FILE--
 <?php
 

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -1,7 +1,8 @@
 --TEST--
 namespace: Zstd\compress()/uncompress()
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 50300) die("Skipped: PHP 5.3+ required."); ?>
+<?php
+if (PHP_VERSION_ID < 50300) die("skip requires PHP 5.3+");
 --FILE--
 <?php
 include(dirname(__FILE__) . '/data.inc');

--- a/tests/alias.phpt
+++ b/tests/alias.phpt
@@ -1,7 +1,8 @@
 --TEST--
 alias functionality
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 50300) die("Skipped: PHP 5.3+ required."); ?>
+<?php
+if (PHP_VERSION_ID < 50300) die("skip requires PHP 5.3+");
 --FILE--
 <?php
 include(dirname(__FILE__) . '/data.inc');

--- a/tests/streams_6.phpt
+++ b/tests/streams_6.phpt
@@ -2,7 +2,7 @@
 compress.zstd read online stream
 --SKIPIF--
 <?php
-if (version_compare(PHP_VERSION, '5.4', '<')) die('skip PHP is too old');
+if (PHP_VERSION_ID < 50400) die("skip requires PHP 5.4+");
 if (getenv("SKIP_ONLINE_TESTS")) die('skip online test');
 if (!extension_loaded('openssl')) die('skip reqiures ext-openssl for https stream');
 ?>

--- a/tests/streams_7.phpt
+++ b/tests/streams_7.phpt
@@ -2,7 +2,7 @@
 compress.zstd read online stream denied
 --SKIPIF--
 <?php
-if (version_compare(PHP_VERSION, '5.4', '<')) die('skip PHP is too old');
+if (PHP_VERSION_ID < 50400) die("skip requires PHP 5.4+");
 ?>
 --INI--
 allow_url_fopen=0


### PR DESCRIPTION
The too old/too new messages were swapped, reported too old when should have said too new.

This also makes tests consistently use `PHP_VERSION_ID`. It's available since [5.2.7](https://www.php.net/manual/en/reserved.constants.php#reserved.constants.core), but was already used by tests, so this is not a new dependency. Also, the change covers only tests, so bumping min version in `package.xml` shouldn't be necessary.