### PR TITLE
fix test to pass with PHP 8

### DIFF
--- a/tests/streams_7.phpt
+++ b/tests/streams_7.phpt
@@ -15,8 +15,8 @@ readfile("compress.zstd://https://github.com/kjdev/php-ext-zstd/raw/master/tests
 --EXPECTF--
 Warning: readfile(): https:// wrapper is disabled in the server configuration by allow_url_fopen=0 in %s
 
-Warning: readfile(https://github.com/kjdev/php-ext-zstd/raw/master/tests/streaming.zst): failed to open stream: no suitable wrapper could be found in %s
+Warning: readfile(https://github.com/kjdev/php-ext-zstd/raw/master/tests/streaming.zst): %sailed to open stream: no suitable wrapper could be found in %s
 
-Warning: readfile(compress.zstd://https://github.com/kjdev/php-ext-zstd/raw/master/tests/streaming.zst): failed to open stream: operation failed in %s
+Warning: readfile(compress.zstd://https://github.com/kjdev/php-ext-zstd/raw/master/tests/streaming.zst): %sailed to open stream: operation failed in %s
 
 ===Done===


### PR DESCRIPTION
```
$ cat tests/streams_7.diff
003+ Warning: readfile(https://github.com/kjdev/php-ext-zstd/raw/master/tests/streaming.zst): Failed to open stream: no suitable wrapper could be found in /work/GIT/pecl-and-ext/zstd/tests/streams_7.php on line 2
003- Warning: readfile(https://github.com/kjdev/php-ext-zstd/raw/master/tests/streaming.zst): failed to open stream: no suitable wrapper could be found in %s
005+ Warning: readfile(compress.zstd://https://github.com/kjdev/php-ext-zstd/raw/master/tests/streaming.zst): Failed to open stream: operation failed in /work/GIT/pecl-and-ext/zstd/tests/streams_7.php on line 2
005- Warning: readfile(compress.zstd://https://github.com/kjdev/php-ext-zstd/raw/master/tests/streaming.zst): failed to open stream: operation failed in %s[remi@builder zstd (master)]$ e tests/streams_7.phpt&

```