### PR TITLE
Add Windows support (incl. AppVeyor CI)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,46 @@
+# general configuration
+version: '{branch}.{build}'
+
+# environment configuration
+image: Visual Studio 2017
+clone_folder: c:\projects\zstd
+environment:
+  BIN_SDK_VER: 2.2.0
+  DEP: libzstd-1.4.5
+  matrix:
+    - PHP_VER: 7.2.31
+      ARCH: x64
+      TS: 0
+      VC: vc15
+    - PHP_VER: 7.2.31
+      ARCH: x86
+      TS: 1
+      VC: vc15
+    - PHP_VER: 7.3.18
+      ARCH: x64
+      TS: 0
+      VC: vc15
+    - PHP_VER: 7.3.18
+      ARCH: x86
+      TS: 1
+      VC: vc15
+    - PHP_VER: 7.4.6
+      ARCH: x64
+      TS: 0
+      VC: vc15
+    - PHP_VER: 7.4.6
+      ARCH: x86
+      TS: 1
+      VC: vc15
+cache:
+  - c:\build-cache -> .appveyor.yml, .appveyor\install.ps1
+install:
+  - ps: .appveyor\install.ps1
+
+# build configuration
+build_script:
+  - ps: .appveyor\build.ps1
+
+# tests configuration
+test_script:
+  - ps: .appveyor\test.ps1

--- a/.appveyor/build.ps1
+++ b/.appveyor/build.ps1
@@ -1,0 +1,28 @@
+$ErrorActionPreference = "Stop"
+
+Set-Location C:\projects\zstd
+
+$task = New-Item 'task.bat' -Force
+Add-Content $task 'call phpize 2>&1'
+Add-Content $task 'call configure --with-php-build=C:\build-cache\deps --enable-zstd --enable-debug-pack 2>&1'
+Add-Content $task 'nmake /nologo 2>&1'
+Add-Content $task 'exit %errorlevel%'
+& "C:\build-cache\php-sdk-$env:BIN_SDK_VER\phpsdk-$env:VC-$env:ARCH.bat" -t $task
+if (-not $?) {
+    throw "building failed with errorlevel $LastExitCode"
+}
+
+$dname = ''
+if ($env:ARCH -eq 'x64') {
+    $dname += 'x64\'
+}
+$dname += 'Release';
+if ($env:TS -eq '1') {
+    $dname += '_TS'
+}
+Copy-Item "$dname\php_zstd.dll" "$env:PHP_PATH\ext\php_zstd.dll"
+
+$ini = New-Item "$env:PHP_PATH\php.ini" -Force
+Add-Content $ini "extension_dir=$env:PHP_PATH\ext"
+Add-Content $ini 'extension=php_openssl.dll'
+Add-Content $ini 'extension=php_zstd.dll'

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -1,0 +1,64 @@
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path 'C:\build-cache')) {
+    [void](New-Item 'C:\build-cache' -ItemType 'directory')
+}
+
+# PHP SDK
+$bname = "php-sdk-$env:BIN_SDK_VER.zip"
+if (-not (Test-Path C:\build-cache\$bname)) {
+    Invoke-WebRequest "https://github.com/microsoft/php-sdk-binary-tools/archive/$bname" -OutFile "C:\build-cache\$bname"
+}
+$dname0 = "php-sdk-binary-tools-php-sdk-$env:BIN_SDK_VER"
+$dname1 = "php-sdk-$env:BIN_SDK_VER"
+if (-not (Test-Path "C:\build-cache\$dname1")) {
+    Expand-Archive "C:\build-cache\$bname" "C:\build-cache"
+    Move-Item "C:\build-cache\$dname0" "C:\build-cache\$dname1"
+}
+
+# PHP devel pack
+$ts_part = ''
+if ('0' -eq $env:TS) {
+    $ts_part = '-nts'
+}
+$bname = "php-devel-pack-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "C:\build-cache\$bname")) {
+    try {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
+    } catch [System.Net.WebException] {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
+    }
+}
+$dname0 = "php-$env:PHP_VER-devel-$env:VC-$env:ARCH"
+$dname1 = "php-$env:PHP_VER$ts_part-devel-$env:VC-$env:ARCH"
+if (-not (Test-Path "C:\build-cache\$dname1")) {
+    Expand-Archive "C:\build-cache\$bname" 'C:\build-cache'
+    if ($dname0 -ne $dname1) {
+        Move-Item "C:\build-cache\$dname0" "C:\build-cache\$dname1"
+    }
+}
+$env:PATH = "C:\build-cache\$dname1;$env:PATH"
+
+# PHP binary
+$bname = "php-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "C:\build-cache\$bname")) {
+    try {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
+    } catch [System.Net.WebException] {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
+    }
+}
+$dname = "php-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH"
+if (-not (Test-Path "C:\build-cache\$dname")) {
+    Expand-Archive "C:\build-cache\$bname" "C:\build-cache\$dname"
+}
+$env:PHP_PATH = "C:\build-cache\$dname"
+$env:PATH = "$env:PHP_PATH;$env:PATH"
+
+# library dependency
+$bname = "$env:DEP-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "C:\build-cache\$bname")) {
+    Invoke-WebRequest "https://windows.php.net/downloads/pecl/deps/$bname" -OutFile "C:\build-cache\$bname"
+    Expand-Archive "C:\build-cache\$bname" 'C:\build-cache\deps'
+}
+$env:PATH = "C:\build-cache\deps\bin;$env:PATH"

--- a/.appveyor/test.ps1
+++ b/.appveyor/test.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = "Stop"
+
+Set-Location C:\projects\zstd
+
+$env:TEST_PHP_EXECUTABLE = "$env:PHP_PATH\php.exe"
+& $env:TEST_PHP_EXECUTABLE 'run-tests.php' --show-diff tests
+if (-not $?) {
+    throw "testing failed with errorlevel $LastExitCode"
+}

--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,11 @@
+ARG_ENABLE("zstd", "zstd support", "yes");
+
+if (PHP_ZSTD != "no") {
+	if (CHECK_LIB("libzstd.lib", "zstd", PHP_ZSTD) &&
+			CHECK_HEADER_ADD_INCLUDE("zstd.h", "CFLAGS_ZSTD", PHP_ZSTD)) {
+		EXTENSION("zstd", "zstd.c", null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+	} else {
+		WARNING("zstd support can't be enabled, libraries or headers are missing");
+		PHP_ZSTD = "no";
+	}
+}

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <file name="LICENSE" role="doc" />
    <file name="README.md" role="doc" />
    <file name="config.m4" role="src" />
+   <file name="config.w32" role="src" />
    <file name="php_zstd.h" role="src" />
    <file name="zstd.c" role="src" />
    <dir name="zstd">


### PR DESCRIPTION
We make the configure option `--enable-zstd` available on Windows, which always builds against an external libzstd.

We also add basic AppVeyor CI support for building the extension and running the test suite.

The [streams_3.php fails on x86 Windows](https://ci.appveyor.com/project/cmb69/php-ext-zstd/builds/33239843) because the compression of PHP_BINARY doesn't appear to be as good as supposed; `$size0` is 109056, and `$size1` is 55206 for me locally.