### PR TITLE
Use Fast Parameter Parsing API

### DIFF
--- a/tests/002.phpt
+++ b/tests/002.phpt
@@ -23,9 +23,9 @@ var_dump(zstd_compress($testclass));
 *** Testing zstd_compress() function with Zero arguments ***
 
 Warning: zstd_compress() expects at least 1 parameter, 0 given in %s on line %d
-bool(false)
+NULL
 *** Testing with incorrect parameters ***
 
-Warning: zstd_compress: expects parameter to be string. in %s on line %d
-bool(false)
+Warning: zstd_compress() expects parameter 1 to be string, object given in %s on line %d
+NULL
 ===Done===

--- a/tests/002_b.phpt
+++ b/tests/002_b.phpt
@@ -29,12 +29,13 @@ try {
 ===Done===
 --EXPECTF--
 *** Testing zstd_compress() function with Zero arguments ***
-ArgumentCountError: zstd_compress() expects at least 1 %s, 0 given in %s:%d
+ArgumentCountError: zstd_compress() expects at least 1 argument, 0 given in %s:%d
 Stack trace:
 #0 %s(%d): zstd_compress()
 #1 {main}
 *** Testing with incorrect parameters ***
-
-Warning: zstd_compress: expects parameter to be string. in %s on line %d
-bool(false)
+TypeError: zstd_compress(): Argument #1 ($data) must be of type string, Tester given in %s:%d
+Stack trace:
+#0 %s(%d): zstd_compress(Object(Tester))
+#1 {main}
 ===Done===

--- a/tests/005.phpt
+++ b/tests/005.phpt
@@ -26,7 +26,7 @@ Warning: zstd_uncompress() expects exactly 1 parameter, 0 given in %s on line %d
 NULL
 *** Testing with incorrect arguments ***
 
-Warning: zstd_uncompress: it was not compressed by zstd in %s on line %d
+Warning: zstd_uncompress(): it was not compressed by zstd in %s on line %d
 bool(false)
 
 Warning: zstd_uncompress() expects parameter 1 to be string, object given in %s on line %d

--- a/tests/005.phpt
+++ b/tests/005.phpt
@@ -23,12 +23,12 @@ var_dump(zstd_uncompress($testclass));
 *** Testing zstd_uncompress() function with Zero arguments ***
 
 Warning: zstd_uncompress() expects exactly 1 parameter, 0 given in %s on line %d
-bool(false)
+NULL
 *** Testing with incorrect arguments ***
 
-Warning: zstd_uncompress: expects parameter to be string. in %s on line %d
+Warning: zstd_uncompress: it was not compressed by zstd in %s on line %d
 bool(false)
 
-Warning: zstd_uncompress: expects parameter to be string. in %s on line %d
-bool(false)
+Warning: zstd_uncompress() expects parameter 1 to be string, object given in %s on line %d
+NULL
 ===DONE===

--- a/tests/005_b.phpt
+++ b/tests/005_b.phpt
@@ -33,15 +33,16 @@ try {
 ===DONE===
 --EXPECTF--
 *** Testing zstd_uncompress() function with Zero arguments ***
-ArgumentCountError: zstd_uncompress() expects exactly 1 %s, 0 given in %s:%d
+ArgumentCountError: zstd_uncompress() expects exactly 1 argument, 0 given in %s:%d
 Stack trace:
 #0 %s(%d): zstd_uncompress()
 #1 {main}
 *** Testing with incorrect arguments ***
 
-Warning: zstd_uncompress: expects parameter to be string. in %s on line %d
+Warning: zstd_uncompress: it was not compressed by zstd in %s on line %d
 bool(false)
-
-Warning: zstd_uncompress: expects parameter to be string. in %s on line %d
-bool(false)
+TypeError: zstd_uncompress(): Argument #1 ($data) must be of type string, Tester given in %s:%d
+Stack trace:
+#0 %s(%d): zstd_uncompress(Object(Tester))
+#1 {main}
 ===DONE===

--- a/tests/005_b.phpt
+++ b/tests/005_b.phpt
@@ -39,7 +39,7 @@ Stack trace:
 #1 {main}
 *** Testing with incorrect arguments ***
 
-Warning: zstd_uncompress: it was not compressed by zstd in %s on line %d
+Warning: zstd_uncompress(): it was not compressed by zstd in %s on line %d
 bool(false)
 TypeError: zstd_uncompress(): Argument #1 ($data) must be of type string, Tester given in %s:%d
 Stack trace:

--- a/tests/006.phpt
+++ b/tests/006.phpt
@@ -21,7 +21,7 @@ var_dump($output);
 bool(true)
 *** Uncompress ***
 
-Warning: zstd_uncompress: it was not compressed by zstd in %s
+Warning: zstd_uncompress(): it was not compressed by zstd in %s
 bool(false)
 bool(false)
 ===Done===

--- a/tests/009.phpt
+++ b/tests/009.phpt
@@ -71,6 +71,6 @@ check_compress($data, 100);
 
 Warning: zstd_compress(): compression level (100) must be within 1..22 or smaller then 0 in %s on line %d
 100 -- 0 -- 
-Warning: zstd_uncompress: it was not compressed by zstd in %s
+Warning: zstd_uncompress(): it was not compressed by zstd in %s
 false
 ===Done===

--- a/tests/009.phpt
+++ b/tests/009.phpt
@@ -69,7 +69,7 @@ check_compress($data, 100);
 -5 -- %d -- true
 *** Invalid Compression Level ***
 
-Warning: zstd_compress: compression level (100) must be within 1..22 or smaller then 0 in %s on line %d
+Warning: zstd_compress(): compression level (100) must be within 1..22 or smaller then 0 in %s on line %d
 100 -- 0 -- 
 Warning: zstd_uncompress: it was not compressed by zstd in %s
 false

--- a/tests/dictionary_01.phpt
+++ b/tests/dictionary_01.phpt
@@ -71,7 +71,7 @@ check_compress($data, $dictionary, 100);
 -5 -- 142 -- %d -- true
 *** Invalid Compression Level ***
 
-Warning: zstd_compress_dict: compression level (100) must be within 1..22 or smaller then 0 in %s on line %d
+Warning: zstd_compress_dict(): compression level (100) must be within 1..22 or smaller then 0 in %s on line %d
 100 -- 142 -- 0 -- 
 Warning: zstd_uncompress_dict: it was not compressed by zstd in %s
 false

--- a/tests/dictionary_01.phpt
+++ b/tests/dictionary_01.phpt
@@ -73,6 +73,6 @@ check_compress($data, $dictionary, 100);
 
 Warning: zstd_compress_dict(): compression level (100) must be within 1..22 or smaller then 0 in %s on line %d
 100 -- 142 -- 0 -- 
-Warning: zstd_uncompress_dict: it was not compressed by zstd in %s
+Warning: zstd_uncompress_dict(): it was not compressed by zstd in %s
 false
 ===Done===

--- a/zstd.c
+++ b/zstd.c
@@ -111,28 +111,11 @@ ZEND_FUNCTION(zstd_compress)
     char *input;
     size_t input_len;
 
-#ifdef FAST_ZPP
     ZEND_PARSE_PARAMETERS_START(1, 2)
         Z_PARAM_STRING(input, input_len)
         Z_PARAM_OPTIONAL
         Z_PARAM_LONG(level)
     ZEND_PARSE_PARAMETERS_END();
-#else
-    zval *data;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC,
-                              "z|l", &data, &level) == FAILURE) {
-        RETURN_NULL();
-    }
-
-    if (Z_TYPE_P(data) != IS_STRING) {
-        ZSTD_WARNING("expects parameter to be string.");
-        RETURN_NULL();
-    }
-
-    input = Z_STRVAL_P(data);
-    input_len = Z_STRLEN_P(data);
-#endif
 
     if (!zstd_check_compress_level(level)) {
         RETURN_FALSE;
@@ -164,26 +147,9 @@ ZEND_FUNCTION(zstd_uncompress)
     char *input;
     size_t input_len;
 
-#ifdef FAST_ZPP
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_STRING(input, input_len)
     ZEND_PARSE_PARAMETERS_END();
-#else
-    zval *data;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS(),
-                              "z", &data) == FAILURE) {
-        RETURN_NULL();
-    }
-
-    if (Z_TYPE_P(data) != IS_STRING) {
-        ZSTD_WARNING("expects parameter to be string.");
-        RETURN_NULL();
-    }
-
-    input = Z_STRVAL_P(data);
-    input_len = Z_STRLEN_P(data);
-#endif
 
     size = ZSTD_getFrameContentSize(input, input_len);
     if (size == ZSTD_CONTENTSIZE_ERROR) {
@@ -271,35 +237,12 @@ ZEND_FUNCTION(zstd_compress_dict)
     char *input, *dict;
     size_t input_len, dict_len;
 
-#ifdef FAST_ZPP
     ZEND_PARSE_PARAMETERS_START(2, 3)
         Z_PARAM_STRING(input, input_len)
         Z_PARAM_STRING(dict, dict_len)
         Z_PARAM_OPTIONAL
         Z_PARAM_LONG(level)
     ZEND_PARSE_PARAMETERS_END();
-#else
-    zval *data, *dictBuffer;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(),
-                              "zz|l", &data, &dictBuffer, &level) == FAILURE) {
-        RETURN_FALSE;
-    }
-    if (Z_TYPE_P(data) != IS_STRING) {
-        zend_error(E_WARNING, "zstd_compress_dict:"
-                   " expects the first parameter to be string.");
-        RETURN_FALSE;
-    }
-    if (Z_TYPE_P(dictBuffer) != IS_STRING) {
-        zend_error(E_WARNING, "zstd_compress_dict:"
-                   " expects the second parameter to be string.");
-        RETURN_FALSE;
-    }
-
-    input = Z_STRVAL_P(data);
-    input_len = Z_STRLEN_P(data);
-    dict = Z_STRVAL_P(dictBuffer);
-    dict_len = Z_STRLEN_P(dictBuffer);
-#endif
 
     if (!zstd_check_compress_level(level)) {
         RETURN_FALSE;
@@ -346,34 +289,10 @@ ZEND_FUNCTION(zstd_uncompress_dict)
     char *input, *dict;
     size_t input_len, dict_len;
 
-#ifdef FAST_ZPP
     ZEND_PARSE_PARAMETERS_START(2, 2)
         Z_PARAM_STRING(input, input_len)
         Z_PARAM_STRING(dict, dict_len)
     ZEND_PARSE_PARAMETERS_END();
-#else
-    zval *data, *dictBuffer;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS(),
-                              "zz", &data, &dictBuffer) == FAILURE) {
-        RETURN_FALSE;
-    }
-    if (Z_TYPE_P(data) != IS_STRING) {
-        zend_error(E_WARNING, "zstd_uncompress_dict:"
-                   " expects the first parameter to be string.");
-        RETURN_FALSE;
-    }
-    if (Z_TYPE_P(dictBuffer) != IS_STRING) {
-        zend_error(E_WARNING, "zstd_uncompress_dict:"
-                   " expects the second parameter to be string.");
-        RETURN_FALSE;
-    }
-
-    input = Z_STRVAL_P(data);
-    input_len = Z_STRLEN_P(data);
-    dict = Z_STRVAL_P(dictBuffer);
-    dict_len = Z_STRLEN_P(dictBuffer);
-#endif
 
     unsigned long long const rSize = ZSTD_getDecompressedSize(input,
                                                               input_len);

--- a/zstd.c
+++ b/zstd.c
@@ -130,11 +130,11 @@ ZEND_FUNCTION(zstd_compress)
     if (ZSTD_IS_ERROR(result)) {
         zend_string_efree(output);
         RETVAL_FALSE;
-    } else {
-        output = zend_string_truncate(output, result, 0);
-        ZSTR_VAL(output)[ZSTR_LEN(output)] = '\0';
-        RETVAL_STR(output);
     }
+
+    output = zend_string_truncate(output, result, 0);
+    ZSTR_VAL(output)[ZSTR_LEN(output)] = '\0';
+    RETVAL_NEW_STR(output);
 }
 
 ZEND_FUNCTION(zstd_uncompress)
@@ -208,7 +208,7 @@ ZEND_FUNCTION(zstd_uncompress)
             }
 
             result = ZSTD_decompressStream(stream, &out, &in);
-            if (ZSTD_isError(result)) {
+            if (ZSTD_IS_ERROR(result)) {
                 zend_string_efree(output);
                 ZSTD_freeDStream(stream);
                 ZSTD_WARNING("can not decompress stream");
@@ -227,7 +227,7 @@ ZEND_FUNCTION(zstd_uncompress)
 
     output = zend_string_truncate(output, result, 0);
     ZSTR_VAL(output)[ZSTR_LEN(output)] = '\0';
-    RETVAL_STR(output);
+    RETVAL_NEW_STR(output);
 }
 
 ZEND_FUNCTION(zstd_compress_dict)
@@ -269,7 +269,7 @@ ZEND_FUNCTION(zstd_compress_dict)
                                                   input,
                                                   input_len,
                                                   cdict);
-    if (ZSTD_isError(cSize)) {
+    if (ZSTD_IS_ERROR(cSize)) {
         efree(cBuff);
         zend_error(E_WARNING, "zstd_compress_dict: %s",
                    ZSTD_getErrorName(cSize));
@@ -388,7 +388,7 @@ static int php_zstd_comp_flush_or_end(php_zstd_stream_data *self, int end)
             self->output.size = self->sizeout;
             self->output.pos  = 0;
             res = ZSTD_compressStream(self->cctx, &self->output, &self->input);
-            if (ZSTD_isError(res)) {
+            if (ZSTD_IS_ERROR(res)) {
                 php_error_docref(NULL, E_WARNING, "libzstd error %s\n", ZSTD_getErrorName(res));
                 ret = EOF;
             }
@@ -406,7 +406,7 @@ static int php_zstd_comp_flush_or_end(php_zstd_stream_data *self, int end)
         } else {
             res = ZSTD_flushStream(self->cctx, &self->output);
         }
-        if (ZSTD_isError(res)) {
+        if (ZSTD_IS_ERROR(res)) {
             php_error_docref(NULL, E_WARNING, "libzstd error %s\n", ZSTD_getErrorName(res));
             ret = EOF;
         }
@@ -517,7 +517,7 @@ static ssize_t php_zstd_decomp_read(php_stream *stream, char *buf, size_t count)
             self->output.pos = 0;
             self->output.size = self->sizeout;
             res = ZSTD_decompressStream(self->dctx, &self->output , &self->input);
-            if (ZSTD_isError(res)) {
+            if (ZSTD_IS_ERROR(res)) {
                 php_error_docref(NULL, E_WARNING, "libzstd error %s\n", ZSTD_getErrorName(res));
 #if PHP_VERSION_ID >= 70400
                 return -1;
@@ -598,7 +598,7 @@ static ssize_t php_zstd_comp_write(php_stream *stream, const char *buf, size_t c
             self->output.size = self->sizeout;
             self->output.pos  = 0;
             res = ZSTD_compressStream(self->cctx, &self->output, &self->input);
-            if (ZSTD_isError(res)) {
+            if (ZSTD_IS_ERROR(res)) {
                 php_error_docref(NULL, E_WARNING, "libzstd error %s\n", ZSTD_getErrorName(res));
 #if PHP_VERSION_ID >= 70400
                 return -1;

--- a/zstd.c
+++ b/zstd.c
@@ -122,10 +122,6 @@ ZEND_FUNCTION(zstd_compress)
 
     size = ZSTD_compressBound(input_len);
     output = (char *)emalloc(size + 1);
-    if (!output) {
-        zend_error(E_WARNING, "zstd_compress: memory error");
-        RETURN_FALSE;
-    }
 
     result = ZSTD_compress(output, size, input, input_len,
                            level);
@@ -183,10 +179,6 @@ ZEND_FUNCTION(zstd_uncompress)
     }
 
     output = emalloc(size);
-    if (!output) {
-        zend_error(E_WARNING, "zstd_uncompress: memory error");
-        RETURN_FALSE;
-    }
 
     if (!streaming) {
         result = ZSTD_decompress(output, size,
@@ -308,10 +300,7 @@ ZEND_FUNCTION(zstd_compress_dict)
 
     size_t const cBuffSize = ZSTD_compressBound(input_len);
     void* const cBuff = emalloc(cBuffSize);
-    if (!cBuff) {
-        zend_error(E_WARNING, "zstd_compress_dict: memory error");
-        RETURN_FALSE;
-    }
+
     ZSTD_CCtx* const cctx = ZSTD_createCCtx();
     if (cctx == NULL) {
         efree(cBuff);
@@ -387,10 +376,6 @@ ZEND_FUNCTION(zstd_uncompress_dict)
         RETURN_FALSE;
     }
     void* const rBuff = emalloc((size_t)rSize);
-    if (!rBuff) {
-        zend_error(E_WARNING, "zstd_uncompress_dict: memory error");
-        RETURN_FALSE;
-    }
 
     ZSTD_DCtx* const dctx = ZSTD_createDCtx();
     if (dctx == NULL) {
@@ -901,10 +886,6 @@ static int APC_SERIALIZER_NAME(zstd)(APC_SERIALIZER_ARGS)
 
     size = ZSTD_compressBound(ZSTR_LEN(var.s));
     *buf = (char*) emalloc(size + 1);
-    if (*buf == NULL) {
-        *buf_len = 0;
-        return 0;
-    }
 
     *buf_len = ZSTD_compress(*buf, size, ZSTR_VAL(var.s), ZSTR_LEN(var.s),
                              DEFAULT_COMPRESS_LEVEL);
@@ -939,10 +920,6 @@ static int APC_UNSERIALIZER_NAME(zstd)(APC_UNSERIALIZER_ARGS)
     }
 
     var = emalloc(size);
-    if (!var) {
-        ZVAL_NULL(value);
-        return 0;
-    }
 
     var_len = ZSTD_decompress(var, size, buf, buf_len);
     if (ZSTD_isError(var_len) || var_len == 0) {


### PR DESCRIPTION
Also: 
* removes checks for MM allocation, inspired by https://github.com/kjdev/php-ext-brotli/commit/8383c9054447769d5c14daf0f1d46835e3467680
* Use string buffer for output to avoid double allocation (that can speedup some usages twice)
* Bunch of small optimizations 