### PR TITLE
Fix in-tree build on indows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,9 +1,17 @@
 ARG_ENABLE("zstd", "zstd support", "yes");
 
 if (PHP_ZSTD != "no") {
-  if (CHECK_HEADER_ADD_INCLUDE("ext/apcu/apc_serializer.h", "CFLAGS_ZSTD", PHP_DIR + "\\include")) {
-    AC_DEFINE("HAVE_APCU_SUPPORT", 1, "APCu support");
-  }
+  if (MODE_PHPIZE) {
+    // PHPIZE
+    if (CHECK_HEADER_ADD_INCLUDE("ext/apcu/apc_serializer.h", "CFLAGS_ZSTD", PHP_DIR + "\\include")) {
+      AC_DEFINE("HAVE_APCU_SUPPORT", 1, "APCu support");
+    }
+	} else {
+    // in-tree build
+    if (get_define("HAVE_APCU")) {
+      AC_DEFINE("HAVE_APCU_SUPPORT", 1, "APCu support");
+    }
+	}
 
   if (CHECK_LIB("libzstd.lib;zstd.lib", "zstd", PHP_ZSTD) &&
       CHECK_HEADER_ADD_INCLUDE("zstd.h", "CFLAGS_ZSTD", PHP_ZSTD)) {

--- a/config.w32
+++ b/config.w32
@@ -6,12 +6,12 @@ if (PHP_ZSTD != "no") {
     if (CHECK_HEADER_ADD_INCLUDE("ext/apcu/apc_serializer.h", "CFLAGS_ZSTD", PHP_DIR + "\\include")) {
       AC_DEFINE("HAVE_APCU_SUPPORT", 1, "APCu support");
     }
-	} else {
+  } else {
     // in-tree build
     if (get_define("HAVE_APCU")) {
       AC_DEFINE("HAVE_APCU_SUPPORT", 1, "APCu support");
     }
-	}
+  }
 
   if (CHECK_LIB("libzstd.lib;zstd.lib", "zstd", PHP_ZSTD) &&
       CHECK_HEADER_ADD_INCLUDE("zstd.h", "CFLAGS_ZSTD", PHP_ZSTD)) {


### PR DESCRIPTION
when do an in-tree build on win32, it will fail on configure:

```plain
 D:\a\lwmbs\lwmbs\build\src\php-src\configure.js(6896, 3) Microsoft JScript runtime error: 'PHP_DIR' is undefined
```

PHP_DIR value is not usable during in-tree configure