### PR TITLE
(minor) rename temp file in tests

### DIFF
--- a/tests/streams_1.phpt
+++ b/tests/streams_1.phpt
@@ -4,7 +4,7 @@ compress.zstd streams basic
 <?php
 include(dirname(__FILE__) . '/data.inc');
 
-$file = dirname(__FILE__) . '/data.out';
+$file = dirname(__FILE__) . '/data_' . basename(__FILE__, ".php") . '.out';
 
 echo "Compression with defaul level\n";
 

--- a/tests/streams_2.phpt
+++ b/tests/streams_2.phpt
@@ -4,7 +4,7 @@ compress.zstd streams and compatibility
 <?php
 include(dirname(__FILE__) . '/data.inc');
 
-$file = dirname(__FILE__) . '/data.out';
+$file = dirname(__FILE__) . '/data_' . basename(__FILE__, ".php") . '.out';
 
 echo "Stream compression + zstd_uncompress\n";
 

--- a/tests/streams_3.phpt
+++ b/tests/streams_3.phpt
@@ -6,8 +6,8 @@ compress.zstd streams and big file
 <?php
 include(dirname(__FILE__) . '/data.inc');
 
-$file1 = dirname(__FILE__) . '/data1.out';
-$file2 = dirname(__FILE__) . '/data2.out';
+$file1 = dirname(__FILE__) . '/data1_' . basename(__FILE__, ".php") . '.out';
+$file2 = dirname(__FILE__) . '/data2_' . basename(__FILE__, ".php") . '.out';
 
 echo "Compress\n";
 var_dump(copy(PHP_BINARY, 'compress.zstd://' . $file1));

--- a/tests/streams_4.phpt
+++ b/tests/streams_4.phpt
@@ -4,7 +4,7 @@ compress.zstd streams with file functions
 <?php
 include(dirname(__FILE__) . '/data.inc');
 
-$file = dirname(__FILE__) . '/data.out';
+$file = dirname(__FILE__) . '/data_' . basename(__FILE__, ".php") . '.out';
 
 echo "Compression\n";
 

--- a/tests/streams_5.phpt
+++ b/tests/streams_5.phpt
@@ -8,7 +8,7 @@ if (LIBZSTD_VERSION_NUMBER < 10400) die("skip needs libzstd 1.4.0");
 <?php
 include(dirname(__FILE__) . '/data.inc');
 
-$file = dirname(__FILE__) . '/data.out';
+$file = dirname(__FILE__) . '/data_' . basename(__FILE__, ".php") . '.out';
 $dictionary = file_get_contents(dirname(__FILE__) . '/data.dic');
 
 echo "Compression\n";


### PR DESCRIPTION
to allow parallel mode (-j#)

Ex: 

```
$ make test TESTS="-j30 --show-diff "
=====================================================================
PHP         : /opt/remi/php83/root/usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.3.0-dev
ZEND_VERSION: 4.3.0-dev
PHP_OS      : Linux - Linux builder.remirepo.net 6.3.5-100.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Tue May 30 15:43:51 UTC 2023 x86_64
INI actual  : /work/GIT/pecl-and-ext/zstd/tmp-php.ini
More .INIs  :  
---------------------------------------------------------------------
PHP         : /opt/remi/php83/root/usr/bin/php-cgi 
PHP_SAPI    : cgi-fcgi
PHP_VERSION : 8.3.0-dev
ZEND_VERSION: 4.3.0-dev
PHP_OS      : Linux - Linux builder.remirepo.net 6.3.5-100.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Tue May 30 15:43:51 UTC 2023 x86_64
INI actual  : /work/GIT/pecl-and-ext/zstd/tmp-php.ini
More .INIs  : 
--------------------------------------------------------------------- 
CWD         : /work/GIT/pecl-and-ext/zstd
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2023-06-06 11:56:04
=====================================================================
Spawning 26 workers... Done in 0.12s
=====================================================================

PASS namespace: Zstd\compress()/uncompress() [tests/007.phpt] 
PASS zstd_uncompress(): basic functionality [tests/004.phpt] 
SKIP APCu serializer registration [tests/apcu_serializer.phpt] reason: need apcu
PASS zstd_compress(): basic functionality [tests/001.phpt] 
PASS compress level constants [tests/011.phpt]    
SKIP zstd_compress(): error conditions [tests/002.phpt] reason: requires PHP <8.0
PASS zstd_compress(): error conditions [tests/002_b.phpt] 
PASS compress.zstd streams with dictionary [tests/streams_5.phpt] 
PASS compress.zstd read online stream denied [tests/streams_7.phpt] 
PASS zstd_uncompress(): error conditions [tests/005_b.phpt] 
PASS zstd_compress_dict(): compress level [tests/dictionary_01.phpt] 
PASS zstd_compress(): compress level [tests/009.phpt] 
PASS compress.zstd use include_path [tests/streams_8.phpt] 
SKIP zstd_compress(): compress level [tests/008.phpt] reason: needs libzstd 1.3.3 or older
PASS zstd_compress_dict(): basic functionality [tests/dictionary.phpt] 
SKIP zstd_uncompress(): error conditions [tests/005.phpt] reason: requires PHP < 8.0
PASS alias functionality [tests/alias.phpt]       
PASS zstd_compress(): variation [tests/003.phpt]  
PASS unexpected exiting when uncompress the wrong format data [tests/006.phpt] 
PASS phpinfo() displays zstd info [tests/info.phpt] 
PASS zstd_uncompress(): streaming archive [tests/010.phpt] 
PASS compress.zstd streams and big file [tests/streams_3.phpt] 
PASS compress.zstd streams with file functions [tests/streams_4.phpt] 
PASS compress.zstd read online stream [tests/streams_6.phpt] 
PASS compress.zstd streams basic [tests/streams_1.phpt] 
PASS compress.zstd streams and compatibility [tests/streams_2.phpt] 
=====================================================================
TIME END 2023-06-06 11:56:04

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :     0
Exts tested     :    16
---------------------------------------------------------------------

Number of tests :    26                22
Tests skipped   :     4 ( 15.4%) --------
Tests warned    :     0 (  0.0%) (  0.0%)
Tests failed    :     0 (  0.0%) (  0.0%)
Tests passed    :    22 ( 84.6%) (100.0%)
---------------------------------------------------------------------
Time taken      :     0 seconds
=====================================================================

```
