### PR TITLE
Enable append mode in extension

### DIFF
--- a/tests/streams_9.phpt
+++ b/tests/streams_9.phpt
@@ -1,0 +1,42 @@
+--TEST--
+compress.zstd streams with file functions, using append mode
+--FILE--
+<?php
+include(dirname(__FILE__) . '/data.inc');
+
+$file = dirname(__FILE__) . '/data_' . basename(__FILE__, ".php") . '.out';
+
+echo "Compression\n";
+
+var_dump($f = fopen('compress.zstd://' . $file, "a"));
+$l = (int)(strlen($data) / 2);
+if ($f) {
+	var_dump(fwrite($f, substr($data, 0, $l)));
+	var_dump(fclose($f));
+}
+
+var_dump($f = fopen('compress.zstd://' . $file, "a"));
+if ($f) {
+	var_dump(fwrite($f, substr($data, $l)));
+	var_dump(fclose($f));
+}
+
+echo "Decompression\n";
+
+$decomp = file_get_contents('compress.zstd://' . $file);
+var_dump($decomp == $data);
+
+@unlink($file);
+?>
+===Done===
+--EXPECTF--
+Compression
+resource(%d) of type (stream)
+int(%d)
+bool(true)
+resource(%d) of type (stream)
+int(%d)
+bool(true)
+Decompression
+bool(true)
+===Done===

--- a/zstd.c
+++ b/zstd.c
@@ -714,7 +714,7 @@ php_stream_zstd_opener(
         return NULL;
     }
 
-    if (!strcmp(mode, "w") || !strcmp(mode, "wb")) {
+    if (!strcmp(mode, "w") || !strcmp(mode, "wb") || !strcmp(mode, "a") || !strcmp(mode, "ab")) {
        compress = 1;
     } else if (!strcmp(mode, "r") || !strcmp(mode, "rb")) {
        compress = 0;


### PR DESCRIPTION
As I see, there is no limit to use Append mode for fwrite.

Zstd lib supports this. E.g. In bash:
```bash
$ echo 'hello ' | zstd >> awesome.zst
$ echo 'there' | zstd >> awesome.zst
$ zstdcat awesome.zst 
hello 
there
```

So I added it to this extensions (no code changes needed except of on "if" statement)