### PR TITLE
Fix incompatible pointer types (32-bit)

### DIFF
--- a/zstd.c
+++ b/zstd.c
@@ -82,13 +82,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_zstd_uncompress_dict, 0, 0, 2)
     ZEND_ARG_INFO(0, dictBuffer)
 ZEND_END_ARG_INFO()
 
-static size_t zstd_check_compress_level(long level)
+static size_t zstd_check_compress_level(zend_long level)
 {
     uint16_t maxLevel = (uint16_t) ZSTD_maxCLevel();
 
 #if ZSTD_VERSION_NUMBER >= 10304
     if (level > maxLevel) {
-        ZSTD_WARNING("compression level (%ld)"
+        ZSTD_WARNING("compression level (" ZEND_LONG_FMT ")"
             " must be within 1..%d or smaller then 0", level, maxLevel);
       return 0;
     }
@@ -121,7 +121,7 @@ ZEND_FUNCTION(zstd_compress)
 {
     zend_string *output;
     size_t size, result;
-    long level = DEFAULT_COMPRESS_LEVEL;
+    zend_long level = DEFAULT_COMPRESS_LEVEL;
 
     char *input;
     size_t input_len;
@@ -154,7 +154,7 @@ ZEND_FUNCTION(zstd_compress)
     output = zend_string_alloc(size, 0);
 
     result = ZSTD_compress(ZSTR_VAL(output), size, input, input_len,
-                           level);
+                           (int)level);
 
     if (ZSTD_IS_ERROR(result)) {
         zend_string_efree(output);
@@ -274,7 +274,7 @@ ZEND_FUNCTION(zstd_uncompress)
 
 ZEND_FUNCTION(zstd_compress_dict)
 {
-    long level = DEFAULT_COMPRESS_LEVEL;
+    zend_long level = DEFAULT_COMPRESS_LEVEL;
 
     zend_string *output;
     char *input, *dict;
@@ -298,7 +298,7 @@ ZEND_FUNCTION(zstd_compress_dict)
     }
     ZSTD_CDict* const cdict = ZSTD_createCDict(dict,
                                                dict_len,
-                                               level);
+                                               (int)level);
     if (!cdict) {
         ZSTD_freeCStream(cctx);
         ZSTD_WARNING("ZSTD_createCDict() error");
@@ -906,8 +906,8 @@ static int APC_UNSERIALIZER_NAME(zstd)(APC_UNSERIALIZER_ARGS)
     if (!result) {
         php_error_docref(NULL, E_NOTICE,
                          "Error at offset %ld of %ld bytes",
-                         (zend_long) (tmp - (unsigned char*) var),
-                         (zend_long) var_len);
+                         (long) (tmp - (unsigned char*) var),
+                         (long) var_len);
         ZVAL_NULL(value);
         result = 0;
     } else {


### PR DESCRIPTION
Using GCC 14 on Fedora 40 this is now a build error:

```
In file included from /usr/include/php/Zend/zend_types.h:25,
                 from /usr/include/php/Zend/zend.h:27,
                 from /usr/include/php/main/php.h:31,
                 from /builddir/build/BUILD/php-zstd-0.13.2/zstd-0.13.2/zstd.c:28:
/builddir/build/BUILD/php-zstd-0.13.2/zstd-0.13.2/zstd.c: In function 'zif_zstd_compress':
/usr/include/php/Zend/zend_API.h:1869:59: error: passing argument 2 of 'zend_parse_arg_long' from incompatible pointer type [-Wincompatible-pointer-types]
 1869 |                 if (UNEXPECTED(!zend_parse_arg_long(_arg, &dest, &is_null, check_null, _i))) { \
/usr/include/php/Zend/zend_portability.h:363:52: note: in definition of macro 'UNEXPECTED'
  363 | # define UNEXPECTED(condition) __builtin_expect(!!(condition), 0)
      |                                                    ^~~~~~~~~
/usr/include/php/Zend/zend_API.h:1876:9: note: in expansion of macro 'Z_PARAM_LONG_EX'
 1876 |         Z_PARAM_LONG_EX(dest, _dummy, 0, 0)
      |         ^~~~~~~~~~~~~~~
/builddir/build/BUILD/php-zstd-0.13.2/zstd-0.13.2/zstd.c:145:9: note: in expansion of macro 'Z_PARAM_LONG'
  145 |         Z_PARAM_LONG(level)
      |         ^~~~~~~~~~~~
In file included from /usr/include/php/main/php.h:35:
/usr/include/php/Zend/zend_API.h:2185:74: note: expected 'zend_long *' {aka 'int *'} but argument is of type 'long int *'
 2185 | static zend_always_inline bool zend_parse_arg_long(zval *arg, zend_long *dest, bool *is_null, bool check_null, uint32_t arg_num)
      |                                                               ~~~~~~~~~~~^~~~
/builddir/build/BUILD/php-zstd-0.13.2/zstd-0.13.2/zstd.c: In function 'zif_zstd_compress_dict':
/usr/include/php/Zend/zend_API.h:1869:59: error: passing argument 2 of 'zend_parse_arg_long' from incompatible pointer type [-Wincompatible-pointer-types]
 1869 |                 if (UNEXPECTED(!zend_parse_arg_long(_arg, &dest, &is_null, check_null, _i))) { \
/usr/include/php/Zend/zend_portability.h:363:52: note: in definition of macro 'UNEXPECTED'
  363 | # define UNEXPECTED(condition) __builtin_expect(!!(condition), 0)
      |                                                    ^~~~~~~~~
/usr/include/php/Zend/zend_API.h:1876:9: note: in expansion of macro 'Z_PARAM_LONG_EX'
 1876 |         Z_PARAM_LONG_EX(dest, _dummy, 0, 0)
      |         ^~~~~~~~~~~~~~~
/builddir/build/BUILD/php-zstd-0.13.2/zstd-0.13.2/zstd.c:287:9: note: in expansion of macro 'Z_PARAM_LONG'
  287 |         Z_PARAM_LONG(level)
      |         ^~~~~~~~~~~~
/usr/include/php/Zend/zend_API.h:2185:74: note: expected 'zend_long *' {aka 'int *'} but argument is of type 'long int *'
 2185 | static zend_always_inline bool zend_parse_arg_long(zval *arg, zend_long *dest, bool *is_null, bool check_null, uint32_t arg_num)

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved compatibility and error messaging in compression functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->