### PR TITLE
Add incremental zstd_(un)compress_init() and zstd_(un)compress_add()

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ LIBZSTD\_VERSION\_STRING       | libzstd version string
 * zstd\_uncompress — Zstandard decompression
 * zstd\_compress\_dict — Zstandard compression using a digested dictionary
 * zstd\_uncompress\_dict — Zstandard decompression using a digested dictionary
+* zstd\_compress_\init — Initialize an incremental compress context
+* zstd\_compress\_add — Incrementally compress data
+* zstd\_uncompress_\init — Initialize an incremental uncompress context
+* zstd\_uncompress\_add — Incrementally uncompress data
+
 
 ### zstd\_compress — Zstandard compression
 
@@ -209,6 +214,88 @@ Zstandard decompression using a digested dictionary.
 Returns the decompressed data or FALSE if an error occurred.
 
 
+### zstd\_compress\_init — Initialize an incremental compress context
+
+#### Description
+
+resource **zstd\_compress\_init** ( [ int $level = ZSTD_COMPRESS_LEVEL_DEFAULT ] )
+
+Initialize an incremental compress context
+
+#### Parameters
+
+* _level_
+
+  The higher the level, the slower the compression. (Defaults to `ZSTD_COMPRESS_LEVEL_DEFAULT`)
+
+#### Return Values
+
+Returns a zstd context resource (zstd.state) on success, or FALSE on failure
+
+
+### zstd\_compress\_add — Incrementally compress data
+
+#### Description
+
+string **zstd\_compress\_addt** ( resource *$context*, string *$data* [, bool *$end* = false ] )
+
+Incrementally compress data
+
+#### Parameters
+
+* _context_
+
+  A context created with `zstd_compress_init()`.
+
+* _data_
+
+  A chunk of data to compress.
+
+* _end_
+
+  Set to true to terminate with the last chunk of data.
+
+#### Return Values
+
+Returns a chunk of compressed data, or FALSE on failure.
+
+
+### zstd\_uncompress\_init — Initialize an incremental uncompress context
+
+#### Description
+
+resource **zstd\_uncompress\_init** ( void )
+
+Initialize an incremental uncompress context
+
+#### Return Values
+
+Returns a zstd context resource (zstd.state) on success, or FALSE on failure
+
+
+### zstd\_uncompress\_add — Incrementally uncompress data
+
+#### Description
+
+string **zstd\_uncompress\_addt** ( resource *$context*, string *$data* )
+
+Incrementally uncompress data
+
+#### Parameters
+
+* _context_
+
+  A context created with `zstd_uncompress_init()`.
+
+* _data_
+
+  A chunk of compressed data.
+
+#### Return Values
+
+Returns a chunk of uncompressed data, or FALSE on failure.
+
+
 ## Namespace
 
 ```
@@ -218,10 +305,16 @@ function compress( $data [, $level = 3 ] )
 function uncompress( $data )
 function compress_dict ( $data, $dict )
 function uncompress_dict ( $data, $dict )
+function compress_init ( [ $level = 3 ] )
+function compress_add ( $context, $data [, $end = false ] )
+function uncompress_init ()
+function uncompress_add ( $context, $data )
+
 ```
 
-`zstd_compress`, `zstd_uncompress`, `zstd_compress_dict` and
-`zstd_uncompress_dict` function alias.
+`zstd_compress`, `zstd_uncompress`, `zstd_compress_dict`,
+`zstd_uncompress_dict`, `zstd_compress_init`, `zstd_compress_add`,
+`zstd_uncompress_init` and `zstd_uncompress_add` function alias.
 
 ## Streams
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Returns a zstd context resource (zstd.state) on success, or FALSE on failure
 
 #### Description
 
-string **zstd\_compress\_addt** ( resource *$context*, string *$data* [, bool *$end* = false ] )
+string **zstd\_compress\_add** ( resource *$context*, string *$data* [, bool *$end* = false ] )
 
 Incrementally compress data
 
@@ -277,7 +277,7 @@ Returns a zstd context resource (zstd.state) on success, or FALSE on failure
 
 #### Description
 
-string **zstd\_uncompress\_addt** ( resource *$context*, string *$data* )
+string **zstd\_uncompress\_add** ( resource *$context*, string *$data* )
 
 Incrementally uncompress data
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Returns the decompressed data or FALSE if an error occurred.
 
 #### Description
 
-resource **zstd\_compress\_init** ( [ int $level = ZSTD_COMPRESS_LEVEL_DEFAULT ] )
+resource **zstd\_compress\_init** ( [ int _$level_ = ZSTD_COMPRESS_LEVEL_DEFAULT ] )
 
 Initialize an incremental compress context
 
@@ -237,7 +237,7 @@ Returns a zstd context resource (zstd.state) on success, or FALSE on failure
 
 #### Description
 
-string **zstd\_compress\_add** ( resource *$context*, string *$data* [, bool *$end* = false ] )
+string **zstd\_compress\_add** ( resource _$context_, string _$data_ [, bool _$end_ = false ] )
 
 Incrementally compress data
 
@@ -277,7 +277,7 @@ Returns a zstd context resource (zstd.state) on success, or FALSE on failure
 
 #### Description
 
-string **zstd\_uncompress\_add** ( resource *$context*, string *$data* )
+string **zstd\_uncompress\_add** ( resource _$context_, string _$data_ )
 
 Incrementally uncompress data
 

--- a/tests/inc.phpt
+++ b/tests/inc.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Incremental compression and decompression
+--FILE--
+<?php
+
+// compression
+$resource = zstd_compress_init();
+$compressed = '';
+$compressed .= zstd_compress_add($resource, 'Hello, ', false);
+$compressed .= zstd_compress_add($resource, 'World!', false);
+$compressed .= zstd_compress_add($resource, '', true);
+
+echo zstd_uncompress($compressed), PHP_EOL;
+
+// uncompression
+$resource = zstd_uncompress_init();
+$uncompressed = '';
+$uncompressed .= zstd_uncompress_add($resource, substr($compressed, 0, 5));
+$uncompressed .= zstd_uncompress_add($resource, substr($compressed, 5));
+
+echo $uncompressed, PHP_EOL;
+?>
+===Done===
+--EXPECTF--
+Hello, World!
+Hello, World!
+===Done===

--- a/tests/inc_comp.phpt
+++ b/tests/inc_comp.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Incremental compression
+--FILE--
+<?php
+include(dirname(__FILE__) . '/data.inc');
+
+$handle= zstd_compress_init();
+var_dump($handle);
+
+$pos= 0;
+$compressed= '';
+while ($pos < strlen($data)) {
+  $chunk= substr($data, $pos, 1024);
+  $compressed.= zstd_compress_add($handle, $chunk, 0);
+  $pos+= strlen($chunk);
+}
+$compressed.= zstd_compress_add($handle, '', 1);
+var_dump(strlen($compressed), strlen($compressed) < strlen($data));
+
+var_dump($data === zstd_uncompress($compressed));
+?>
+===Done===
+--EXPECTF--
+resource(%d) of type (zstd.state)
+int(%d)
+bool(true)
+bool(true)
+===Done===

--- a/tests/inc_comp.phpt
+++ b/tests/inc_comp.phpt
@@ -6,17 +6,17 @@ include(dirname(__FILE__) . '/data.inc');
 
 foreach ([128, 512, 1024] as $size) {
   var_dump($size);
-  $handle= zstd_compress_init();
+  $handle = zstd_compress_init();
   var_dump($handle);
 
   $pos= 0;
-  $compressed= '';
+  $compressed = '';
   while ($pos < strlen($data)) {
-    $chunk= substr($data, $pos, $size);
-    $compressed.= zstd_compress_add($handle, $chunk, 0);
-    $pos+= strlen($chunk);
+    $chunk = substr($data, $pos, $size);
+    $compressed .= zstd_compress_add($handle, $chunk, false);
+    $pos += strlen($chunk);
   }
-  $compressed.= zstd_compress_add($handle, '', 1);
+  $compressed .= zstd_compress_add($handle, '', true);
   var_dump(strlen($compressed), strlen($compressed) < strlen($data));
 
   var_dump($data === zstd_uncompress($compressed));

--- a/tests/inc_comp.phpt
+++ b/tests/inc_comp.phpt
@@ -4,23 +4,37 @@ Incremental compression
 <?php
 include(dirname(__FILE__) . '/data.inc');
 
-$handle= zstd_compress_init();
-var_dump($handle);
+foreach ([128, 512, 1024] as $size) {
+  var_dump($size);
+  $handle= zstd_compress_init();
+  var_dump($handle);
 
-$pos= 0;
-$compressed= '';
-while ($pos < strlen($data)) {
-  $chunk= substr($data, $pos, 1024);
-  $compressed.= zstd_compress_add($handle, $chunk, 0);
-  $pos+= strlen($chunk);
+  $pos= 0;
+  $compressed= '';
+  while ($pos < strlen($data)) {
+    $chunk= substr($data, $pos, $size);
+    $compressed.= zstd_compress_add($handle, $chunk, 0);
+    $pos+= strlen($chunk);
+  }
+  $compressed.= zstd_compress_add($handle, '', 1);
+  var_dump(strlen($compressed), strlen($compressed) < strlen($data));
+
+  var_dump($data === zstd_uncompress($compressed));
 }
-$compressed.= zstd_compress_add($handle, '', 1);
-var_dump(strlen($compressed), strlen($compressed) < strlen($data));
-
-var_dump($data === zstd_uncompress($compressed));
 ?>
 ===Done===
 --EXPECTF--
+int(128)
+resource(%d) of type (zstd.state)
+int(%d)
+bool(true)
+bool(true)
+int(512)
+resource(%d) of type (zstd.state)
+int(%d)
+bool(true)
+bool(true)
+int(1024)
 resource(%d) of type (zstd.state)
 int(%d)
 bool(true)

--- a/tests/inc_decomp.phpt
+++ b/tests/inc_decomp.phpt
@@ -4,22 +4,22 @@ Incremental decompression
 <?php
 include(dirname(__FILE__) . '/data.inc');
 
-$compressed= zstd_compress($data);
+$compressed = zstd_compress($data);
 
 foreach ([128, 512, 1024] as $size) {
   var_dump($size);
-  $handle= zstd_uncompress_init();
+  $handle = zstd_uncompress_init();
   var_dump($handle);
 
   $pos= 0;
-  $decompressed= '';
+  $uncompressed = '';
   while ($pos < strlen($compressed)) {
-    $chunk= substr($compressed, $pos, $size);
-    $decompressed.= zstd_uncompress_add($handle, $chunk);
-    $pos+= strlen($chunk);
+    $chunk = substr($compressed, $pos, $size);
+    $uncompressed .= zstd_uncompress_add($handle, $chunk);
+    $pos += strlen($chunk);
   }
 
-  var_dump($data === $decompressed);
+  var_dump($data === $uncompressed);
 }
 ?>
 ===Done===

--- a/tests/inc_decomp.phpt
+++ b/tests/inc_decomp.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Incremental decompression
+--FILE--
+<?php
+include(dirname(__FILE__) . '/data.inc');
+
+$compressed= zstd_compress($data);
+
+foreach ([128, 512, 1024] as $size) {
+  var_dump($size);
+  $handle= zstd_uncompress_init();
+  var_dump($handle);
+
+  $pos= 0;
+  $decompressed= '';
+  while ($pos < strlen($compressed)) {
+    $chunk= substr($compressed, $pos, 1024);
+    $decompressed.= zstd_uncompress_add($handle, $chunk);
+    $pos+= strlen($chunk);
+  }
+
+  var_dump($data === $decompressed);
+}
+?>
+===Done===
+--EXPECTF--
+int(128)
+resource(%d) of type (zstd.state)
+bool(true)
+int(512)
+resource(%d) of type (zstd.state)
+bool(true)
+int(1024)
+resource(%d) of type (zstd.state)
+bool(true)
+===Done===

--- a/tests/inc_decomp.phpt
+++ b/tests/inc_decomp.phpt
@@ -14,7 +14,7 @@ foreach ([128, 512, 1024] as $size) {
   $pos= 0;
   $decompressed= '';
   while ($pos < strlen($compressed)) {
-    $chunk= substr($compressed, $pos, 1024);
+    $chunk= substr($compressed, $pos, $size);
     $decompressed.= zstd_uncompress_add($handle, $chunk);
     $pos+= strlen($chunk);
   }

--- a/tests/inc_ns.phpt
+++ b/tests/inc_ns.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Incremental compression and decompression (namespaces)
+--FILE--
+<?php
+
+// compression
+$resource = \Zstd\compress_init();
+$compressed = '';
+$compressed .= \Zstd\compress_add($resource, 'Hello, ', false);
+$compressed .= \Zstd\compress_add($resource, 'World!', false);
+$compressed .= \Zstd\compress_add($resource, '', true);
+
+echo \Zstd\uncompress($compressed), PHP_EOL;
+
+// uncompression
+$resource = \Zstd\uncompress_init();
+$uncompressed = '';
+$uncompressed .= \Zstd\uncompress_add($resource, substr($compressed, 0, 5));
+$uncompressed .= \Zstd\uncompress_add($resource, substr($compressed, 5));
+
+echo $uncompressed, PHP_EOL;
+?>
+===Done===
+--EXPECTF--
+Hello, World!
+Hello, World!
+===Done===

--- a/zstd.c
+++ b/zstd.c
@@ -540,7 +540,6 @@ ZEND_FUNCTION(zstd_compress_add)
 ZEND_FUNCTION(zstd_uncompress_init)
 {
     php_zstd_context *ctx = php_zstd_output_handler_context_init();
-    size_t result;
 
     ctx->dctx = ZSTD_createDCtx();
     if (ctx->dctx == NULL) {
@@ -565,7 +564,6 @@ ZEND_FUNCTION(zstd_uncompress_add)
     php_zstd_context *ctx;
     char *in_buf;
     size_t in_size;
-    zend_bool end = 0;
     smart_string out = {0};
 
     ZEND_PARSE_PARAMETERS_START(2, 2)

--- a/zstd.c
+++ b/zstd.c
@@ -549,7 +549,7 @@ ZEND_FUNCTION(zstd_uncompress_init)
 
     ZSTD_DCtx_reset(ctx->dctx, ZSTD_reset_session_only);
 
-    ctx->output.size = ZSTD_CStreamOutSize();
+    ctx->output.size = ZSTD_DStreamOutSize();
     ctx->output.dst  = emalloc(ctx->output.size);
     ctx->output.pos  = 0;
 

--- a/zstd.c
+++ b/zstd.c
@@ -455,7 +455,10 @@ static void php_zstd_output_handler_context_free(php_zstd_context *ctx)
 static void php_zstd_state_rsrc_dtor(zend_resource *res)
 {
     php_zstd_context *ctx = zend_fetch_resource(res, NULL, le_state);
-    php_zstd_output_handler_context_free(ctx);
+    if (ctx) {
+        php_zstd_output_handler_context_free(ctx);
+        efree(ctx);
+    }
 }
 
 ZEND_FUNCTION(zstd_compress_init)
@@ -579,12 +582,12 @@ ZEND_FUNCTION(zstd_uncompress_add)
 
     ZSTD_inBuffer in = { in_buf, in_size, 0 };
     size_t res = 1;
-    uint64_t size;
+    const size_t grow = ZSTD_DStreamOutSize();
 
     ctx->output.pos = 0;
     while (in.pos < in.size && res > 0) {
         if (ctx->output.pos == ctx->output.size) {
-            ctx->output.size += size;
+            ctx->output.size += grow;
             ctx->output.dst = erealloc(ctx->output.dst, ctx->output.size);
         }
 

--- a/zstd.c
+++ b/zstd.c
@@ -544,7 +544,7 @@ ZEND_FUNCTION(zstd_uncompress_init)
     ctx->dctx = ZSTD_createDCtx();
     if (ctx->dctx == NULL) {
         efree(ctx);
-        ZSTD_WARNING("ZSTD_createCCtx() error");
+        ZSTD_WARNING("ZSTD_createDCtx() error");
         RETURN_FALSE;
     }
     ctx->cdict = NULL;

--- a/zstd.c
+++ b/zstd.c
@@ -584,13 +584,13 @@ ZEND_FUNCTION(zstd_uncompress_add)
     size_t res = 1;
     const size_t grow = ZSTD_DStreamOutSize();
 
-    ctx->output.pos = 0;
     while (in.pos < in.size && res > 0) {
         if (ctx->output.pos == ctx->output.size) {
             ctx->output.size += grow;
             ctx->output.dst = erealloc(ctx->output.dst, ctx->output.size);
         }
 
+        ctx->output.pos = 0;
         res = ZSTD_decompressStream(ctx->dctx, &ctx->output, &in);
         if (ZSTD_isError(res)) {
             php_error_docref(NULL, E_WARNING,

--- a/zstd.stub.php
+++ b/zstd.stub.php
@@ -10,6 +10,26 @@ namespace {
 
   function zstd_uncompress_dict(string $data, string $dict): string|false {}
 
+  /**
+   * @return resource|false
+   */
+  function zstd_compress_init(int $level= 3) {}
+
+  /**
+   * @param resource $context
+   */
+  function zstd_compress_add($context, string $data, bool $end = false): string|false {}
+
+  /**
+   * @return resource|false
+   */
+  function zstd_uncompress_init() {}
+
+  /**
+   * @param resource $context
+   */
+  function zstd_uncompress_add($context, string $data): string|false {}
+
 }
 
 namespace Zstd {
@@ -21,5 +41,25 @@ namespace Zstd {
   function compress_dict(string $data, string $dict, int $level = 3): string|false {}
 
   function uncompress_dict(string $data, string $dict): string|false {}
+
+  /**
+   * @return resource|false
+   */
+  function compress_init(int $level= 3) {}
+
+  /**
+   * @param resource $context
+   */
+  function compress_add($context, string $data, bool $end = false): string|false {}
+
+  /**
+   * @return resource|false
+   */
+  function uncompress_init() {}
+
+  /**
+   * @param resource $context
+   */
+  function uncompress_add($context, string $data): string|false {}
 
 }


### PR DESCRIPTION
Implements feature suggested in #64 

* [x] Implementation
* [x] PHPT tests
* [x] Incorporate changes suggested by Code Rabbit 

* * *  

## Example
```php
// compression
$resource = zstd_compress_init();
$compressed = '';
$compressed .= zstd_compress_add($resource, 'Hello, ', false);
$compressed .= zstd_compress_add($resource, 'World!', false);
$compressed .= zstd_compress_add($resource, '', true);

echo zstd_uncompress($compressed), PHP_EOL; // Hello, World!

// uncompression
$resource = zstd_uncompress_init();
$uncompressed = '';
$uncompressed .= zstd_uncompress_add($resource, substr($compressed, 0, 5));
$uncompressed .= zstd_uncompress_add($resource, substr($compressed, 5));

echo $uncompressed, PHP_EOL; // Hello, World!
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced incremental (streaming) compression and decompression support for zstd, allowing data to be processed in chunks.
  - Added new functions for initializing and managing compression/decompression contexts in both the global and Zstd namespaces.
- **Tests**
  - Added multiple tests to verify the correctness of incremental compression and decompression functionality across various chunk sizes and namespace usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->