### PR TITLE
Add incremental zstd_(un)compress_init() and zstd_(un)compress_add()

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ LIBZSTD\_VERSION\_STRING       | libzstd version string
 * zstd\_uncompress — Zstandard decompression
 * zstd\_compress\_dict — Zstandard compression using a digested dictionary
 * zstd\_uncompress\_dict — Zstandard decompression using a digested dictionary
-* zstd\_compress_\init — Initialize an incremental compress context
+* zstd\_compress\_init — Initialize an incremental compress context
 * zstd\_compress\_add — Incrementally compress data
-* zstd\_uncompress_\init — Initialize an incremental uncompress context
+* zstd\_uncompress\_init — Initialize an incremental uncompress context
 * zstd\_uncompress\_add — Incrementally uncompress data
 
 
@@ -270,7 +270,7 @@ Initialize an incremental uncompress context
 
 #### Return Values
 
-Returns a zstd context instance success, or FALSE on failure
+Returns a zstd context instance on success, or FALSE on failure
 
 
 ### zstd\_uncompress\_add — Incrementally uncompress data
@@ -314,7 +314,7 @@ function uncompress_add ( $context, $data )
 
 `zstd_compress`, `zstd_uncompress`, `zstd_compress_dict`,
 `zstd_uncompress_dict`, `zstd_compress_init`, `zstd_compress_add`,
-`zstd_uncompress_init` and `zstd_uncompress_add` function alias.
+`zstd_uncompress_init` and `zstd_uncompress_add` function aliases.
 
 ## Streams
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ LIBZSTD\_VERSION\_STRING       | libzstd version string
 * zstd\_uncompress — Zstandard decompression
 * zstd\_compress\_dict — Zstandard compression using a digested dictionary
 * zstd\_uncompress\_dict — Zstandard decompression using a digested dictionary
+* zstd\_compress_\init — Initialize an incremental compress context
+* zstd\_compress\_add — Incrementally compress data
+* zstd\_uncompress_\init — Initialize an incremental uncompress context
+* zstd\_uncompress\_add — Incrementally uncompress data
+
 
 ### zstd\_compress — Zstandard compression
 
@@ -209,6 +214,88 @@ Zstandard decompression using a digested dictionary.
 Returns the decompressed data or FALSE if an error occurred.
 
 
+### zstd\_compress\_init — Initialize an incremental compress context
+
+#### Description
+
+resource **zstd\_compress\_init** ( [ int _$level_ = ZSTD_COMPRESS_LEVEL_DEFAULT ] )
+
+Initialize an incremental compress context
+
+#### Parameters
+
+* _level_
+
+  The higher the level, the slower the compression. (Defaults to `ZSTD_COMPRESS_LEVEL_DEFAULT`)
+
+#### Return Values
+
+Returns a zstd context instance on success, or FALSE on failure
+
+
+### zstd\_compress\_add — Incrementally compress data
+
+#### Description
+
+string **zstd\_compress\_add** ( ZstdContext _$context_, string _$data_ [, bool _$end_ = false ] )
+
+Incrementally compress data
+
+#### Parameters
+
+* _context_
+
+  A context created with `zstd_compress_init()`.
+
+* _data_
+
+  A chunk of data to compress.
+
+* _end_
+
+  Set to true to terminate with the last chunk of data.
+
+#### Return Values
+
+Returns a chunk of compressed data, or FALSE on failure.
+
+
+### zstd\_uncompress\_init — Initialize an incremental uncompress context
+
+#### Description
+
+resource **zstd\_uncompress\_init** ( void )
+
+Initialize an incremental uncompress context
+
+#### Return Values
+
+Returns a zstd context instance success, or FALSE on failure
+
+
+### zstd\_uncompress\_add — Incrementally uncompress data
+
+#### Description
+
+string **zstd\_uncompress\_add** ( ZstdContext _$context_, string _$data_ )
+
+Incrementally uncompress data
+
+#### Parameters
+
+* _context_
+
+  A context created with `zstd_uncompress_init()`.
+
+* _data_
+
+  A chunk of compressed data.
+
+#### Return Values
+
+Returns a chunk of uncompressed data, or FALSE on failure.
+
+
 ## Namespace
 
 ```
@@ -218,10 +305,16 @@ function compress( $data [, $level = 3 ] )
 function uncompress( $data )
 function compress_dict ( $data, $dict )
 function uncompress_dict ( $data, $dict )
+function compress_init ( [ $level = 3 ] )
+function compress_add ( $context, $data [, $end = false ] )
+function uncompress_init ()
+function uncompress_add ( $context, $data )
+
 ```
 
-`zstd_compress`, `zstd_uncompress`, `zstd_compress_dict` and
-`zstd_uncompress_dict` function alias.
+`zstd_compress`, `zstd_uncompress`, `zstd_compress_dict`,
+`zstd_uncompress_dict`, `zstd_compress_init`, `zstd_compress_add`,
+`zstd_uncompress_init` and `zstd_uncompress_add` function alias.
 
 ## Streams
 

--- a/tests/inc.phpt
+++ b/tests/inc.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Incremental compression and decompression
+--FILE--
+<?php
+
+// compression
+$resource = zstd_compress_init();
+$compressed = '';
+$compressed .= zstd_compress_add($resource, 'Hello, ', false);
+$compressed .= zstd_compress_add($resource, 'World!', false);
+$compressed .= zstd_compress_add($resource, '', true);
+
+echo zstd_uncompress($compressed), PHP_EOL;
+
+// uncompression
+$resource = zstd_uncompress_init();
+$uncompressed = '';
+$uncompressed .= zstd_uncompress_add($resource, substr($compressed, 0, 5));
+$uncompressed .= zstd_uncompress_add($resource, substr($compressed, 5));
+
+echo $uncompressed, PHP_EOL;
+?>
+===Done===
+--EXPECTF--
+Hello, World!
+Hello, World!
+===Done===

--- a/tests/inc_comp.phpt
+++ b/tests/inc_comp.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Incremental compression
+--FILE--
+<?php
+include(dirname(__FILE__) . '/data.inc');
+
+foreach ([128, 512, 1024] as $size) {
+  var_dump($size);
+  $handle = zstd_compress_init();
+  var_dump($handle);
+
+  $pos= 0;
+  $compressed = '';
+  while ($pos < strlen($data)) {
+    $chunk = substr($data, $pos, $size);
+    $compressed .= zstd_compress_add($handle, $chunk, false);
+    $pos += strlen($chunk);
+  }
+  $compressed .= zstd_compress_add($handle, '', true);
+  var_dump(strlen($compressed), strlen($compressed) < strlen($data));
+
+  var_dump($data === zstd_uncompress($compressed));
+}
+?>
+===Done===
+--EXPECTF--
+int(128)
+object(ZstdContext)#%d (0) {
+}
+int(%d)
+bool(true)
+bool(true)
+int(512)
+object(ZstdContext)#%d (0) {
+}
+int(%d)
+bool(true)
+bool(true)
+int(1024)
+object(ZstdContext)#%d (0) {
+}
+int(%d)
+bool(true)
+bool(true)
+===Done===

--- a/tests/inc_decomp.phpt
+++ b/tests/inc_decomp.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Incremental decompression
+--FILE--
+<?php
+include(dirname(__FILE__) . '/data.inc');
+
+$compressed = zstd_compress($data);
+
+foreach ([128, 512, 1024] as $size) {
+  var_dump($size);
+  $handle = zstd_uncompress_init();
+  var_dump($handle);
+
+  $pos= 0;
+  $uncompressed = '';
+  while ($pos < strlen($compressed)) {
+    $chunk = substr($compressed, $pos, $size);
+    $uncompressed .= zstd_uncompress_add($handle, $chunk);
+    $pos += strlen($chunk);
+  }
+
+  var_dump($data === $uncompressed);
+}
+?>
+===Done===
+--EXPECTF--
+int(128)
+object(ZstdContext)#%d (0) {
+}
+bool(true)
+int(512)
+object(ZstdContext)#%d (0) {
+}
+bool(true)
+int(1024)
+object(ZstdContext)#%d (0) {
+}
+bool(true)
+===Done===

--- a/tests/inc_ns.phpt
+++ b/tests/inc_ns.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Incremental compression and decompression (namespaces)
+--FILE--
+<?php
+
+// compression
+$resource = \Zstd\compress_init();
+$compressed = '';
+$compressed .= \Zstd\compress_add($resource, 'Hello, ', false);
+$compressed .= \Zstd\compress_add($resource, 'World!', false);
+$compressed .= \Zstd\compress_add($resource, '', true);
+
+echo \Zstd\uncompress($compressed), PHP_EOL;
+
+// uncompression
+$resource = \Zstd\uncompress_init();
+$uncompressed = '';
+$uncompressed .= \Zstd\uncompress_add($resource, substr($compressed, 0, 5));
+$uncompressed .= \Zstd\uncompress_add($resource, substr($compressed, 5));
+
+echo $uncompressed, PHP_EOL;
+?>
+===Done===
+--EXPECTF--
+Hello, World!
+Hello, World!
+===Done===

--- a/zstd.c
+++ b/zstd.c
@@ -64,13 +64,13 @@ static const zend_function_entry zstd_context_methods[] = {
     ZEND_FE_END
 };
 
-struct _php_zstd_context {
+typedef struct _php_zstd_context {
     ZSTD_CCtx* cctx;
     ZSTD_DCtx* dctx;
     ZSTD_CDict *cdict;
     ZSTD_inBuffer input;
     ZSTD_outBuffer output;
-};
+} php_zstd_context;
 
 typedef struct {
     php_zstd_context *ctx;

--- a/zstd.c
+++ b/zstd.c
@@ -35,6 +35,7 @@
 #include <ext/standard/php_var.h>
 #include <ext/apcu/apc_serializer.h>
 #include <zend_smart_str.h>
+#include <zend_API.h>
 #endif
 #include "php_zstd.h"
 
@@ -58,12 +59,87 @@
 #define zend_string_efree(string) zend_string_free(string)
 #endif
 
+zend_class_entry *zstd_context_ptr;
+static const zend_function_entry zstd_context_methods[] = {
+    ZEND_FE_END
+};
+
+struct _php_zstd_context {
+    ZSTD_CCtx* cctx;
+    ZSTD_DCtx* dctx;
+    ZSTD_CDict *cdict;
+    ZSTD_inBuffer input;
+    ZSTD_outBuffer output;
+};
+
+typedef struct {
+    php_zstd_context *ctx;
+    zend_object zo;
+} zstd_context_object;
+
+static inline zstd_context_object *zstd_context_object_from_obj(zend_object *obj) {
+    return (zstd_context_object*)((char*)(obj) - XtOffsetOf(zstd_context_object, zo));
+}
+
+#define Z_ZSTD_CONTEXT_P(zv)  zstd_context_object_from_obj(Z_OBJ_P((zv)))
+
+static zend_object_handlers zstd_context_object_handlers;
+
+static php_zstd_context* php_zstd_output_handler_context_init(void)
+{
+    php_zstd_context *ctx
+        = (php_zstd_context *) ecalloc(1, sizeof(php_zstd_context));
+    ctx->cctx = NULL;
+    ctx->dctx = NULL;
+    return ctx;
+}
+
+static void php_zstd_output_handler_context_free(php_zstd_context *ctx)
+{
+    if (ctx->cctx) {
+        ZSTD_freeCCtx(ctx->cctx);
+        ctx->cctx = NULL;
+    }
+    if (ctx->dctx) {
+        ZSTD_freeDCtx(ctx->dctx);
+        ctx->dctx = NULL;
+    }
+    if (ctx->cdict) {
+        ZSTD_freeCDict(ctx->cdict);
+        ctx->cdict = NULL;
+    }
+    if (ctx->output.dst) {
+        efree(ctx->output.dst);
+        ctx->output.dst = NULL;
+    }
+}
+
+static zend_object *zstd_context_objects_new(zend_class_entry *class_type)
+{
+    zstd_context_object *intern = zend_object_alloc(sizeof(zstd_context_object), class_type);
+
+    zend_object_std_init(&intern->zo, class_type);
+    object_properties_init(&intern->zo, class_type);
+    return &intern->zo;
+}
+
+static void zstd_context_free_objects_storage(zend_object *object)
+{
+    zstd_context_object *intern = zstd_context_object_from_obj(object);
+    if (intern->ctx) {
+        php_zstd_output_handler_context_free(intern->ctx);
+        efree(intern->ctx);
+    }
+    zend_object_std_dtor(&intern->zo);
+}
+
 #define ZSTD_WARNING(...) \
     php_error_docref(NULL, E_WARNING, __VA_ARGS__)
 
 #define ZSTD_IS_ERROR(result) \
     UNEXPECTED(ZSTD_isError(result))
 
+/* One-shot functions */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zstd_compress, 0, 0, 1)
     ZEND_ARG_INFO(0, data)
     ZEND_ARG_INFO(0, level)
@@ -82,6 +158,25 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zstd_uncompress_dict, 0, 0, 2)
     ZEND_ARG_INFO(0, data)
     ZEND_ARG_INFO(0, dictBuffer)
+ZEND_END_ARG_INFO()
+
+/* Incremental functions */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zstd_compress_init, 0, 0, 0)
+    ZEND_ARG_INFO(0, level)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zstd_compress_add, 0, 0, 2)
+    ZEND_ARG_INFO(0, context)
+    ZEND_ARG_INFO(0, data)
+    ZEND_ARG_INFO(0, end)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zstd_uncompress_init, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zstd_uncompress_add, 0, 0, 2)
+    ZEND_ARG_INFO(0, context)
+    ZEND_ARG_INFO(0, data)
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 80000
@@ -393,6 +488,150 @@ ZEND_FUNCTION(zstd_uncompress_dict)
     RETVAL_NEW_STR(output);
 }
 
+ZEND_FUNCTION(zstd_compress_init)
+{
+    zend_long level = DEFAULT_COMPRESS_LEVEL;
+
+    ZEND_PARSE_PARAMETERS_START(0, 1)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(level)
+    ZEND_PARSE_PARAMETERS_END();
+
+    if (!zstd_check_compress_level(level)) {
+        RETURN_FALSE;
+    }
+
+    php_zstd_context *ctx = php_zstd_output_handler_context_init();
+
+    ctx->cctx = ZSTD_createCCtx();
+    if (ctx->cctx == NULL) {
+        efree(ctx);
+        ZSTD_WARNING("ZSTD_createCCtx() error");
+        RETURN_FALSE;
+    }
+    ctx->cdict = NULL;
+
+    ZSTD_CCtx_reset(ctx->cctx, ZSTD_reset_session_only);
+    ZSTD_CCtx_setParameter(ctx->cctx, ZSTD_c_compressionLevel, level);
+
+    ctx->output.size = ZSTD_CStreamOutSize();
+    ctx->output.dst  = emalloc(ctx->output.size);
+    ctx->output.pos  = 0;
+
+    object_init_ex(return_value, zstd_context_ptr);
+    Z_ZSTD_CONTEXT_P(return_value)->ctx = ctx;
+}
+
+ZEND_FUNCTION(zstd_compress_add)
+{
+    zend_object *context;
+    php_zstd_context *ctx;
+    char *in_buf;
+    size_t in_size;
+    zend_bool end = 0;
+    smart_string out = {0};
+
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_OBJ_OF_CLASS(context, zstd_context_ptr)
+        Z_PARAM_STRING(in_buf, in_size)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(end)
+    ZEND_PARSE_PARAMETERS_END();
+
+    ctx = zstd_context_object_from_obj(context)->ctx;
+    if (ctx == NULL || ctx->cctx == NULL) {
+        php_error_docref(NULL, E_WARNING,
+                         "ZStandard incremental compress resource failed");
+        RETURN_FALSE;
+    }
+
+    ZSTD_inBuffer in = { in_buf, in_size, 0 };
+    size_t res;
+
+    do {
+        ctx->output.pos = 0;
+        res = ZSTD_compressStream2(ctx->cctx, &ctx->output,
+                                   &in, end ? ZSTD_e_end : ZSTD_e_flush);
+        if (ZSTD_isError(res)) {
+            php_error_docref(NULL, E_WARNING,
+                             "libzstd error %s\n", ZSTD_getErrorName(res));
+            smart_string_free(&out);
+            RETURN_FALSE;
+        }
+        smart_string_appendl(&out, ctx->output.dst, ctx->output.pos);
+    } while (res > 0);
+
+    RETVAL_STRINGL(out.c, out.len);
+    smart_string_free(&out);
+}
+
+ZEND_FUNCTION(zstd_uncompress_init)
+{
+    php_zstd_context *ctx = php_zstd_output_handler_context_init();
+
+    ctx->dctx = ZSTD_createDCtx();
+    if (ctx->dctx == NULL) {
+        efree(ctx);
+        ZSTD_WARNING("ZSTD_createDCtx() error");
+        RETURN_FALSE;
+    }
+    ctx->cdict = NULL;
+
+    ZSTD_DCtx_reset(ctx->dctx, ZSTD_reset_session_only);
+
+    ctx->output.size = ZSTD_DStreamOutSize();
+    ctx->output.dst  = emalloc(ctx->output.size);
+    ctx->output.pos  = 0;
+
+    object_init_ex(return_value, zstd_context_ptr);
+    Z_ZSTD_CONTEXT_P(return_value)->ctx = ctx;
+}
+
+ZEND_FUNCTION(zstd_uncompress_add)
+{
+    zend_object *context;
+    php_zstd_context *ctx;
+    char *in_buf;
+    size_t in_size;
+    smart_string out = {0};
+
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_OBJ_OF_CLASS(context, zstd_context_ptr)
+        Z_PARAM_STRING(in_buf, in_size)
+    ZEND_PARSE_PARAMETERS_END();
+
+    ctx = zstd_context_object_from_obj(context)->ctx;
+    if (ctx == NULL || ctx->dctx == NULL) {
+        php_error_docref(NULL, E_WARNING,
+                         "ZStandard incremental uncompress resource failed");
+        RETURN_FALSE;
+    }
+
+    ZSTD_inBuffer in = { in_buf, in_size, 0 };
+    size_t res = 1;
+    const size_t grow = ZSTD_DStreamOutSize();
+
+    while (in.pos < in.size && res > 0) {
+        if (ctx->output.pos == ctx->output.size) {
+            ctx->output.size += grow;
+            ctx->output.dst = erealloc(ctx->output.dst, ctx->output.size);
+        }
+
+        ctx->output.pos = 0;
+        res = ZSTD_decompressStream(ctx->dctx, &ctx->output, &in);
+        if (ZSTD_isError(res)) {
+            php_error_docref(NULL, E_WARNING,
+                             "libzstd error %s\n", ZSTD_getErrorName(res));
+            smart_string_free(&out);
+            RETURN_FALSE;
+        }
+
+        smart_string_appendl(&out, ctx->output.dst, ctx->output.pos);
+    }
+
+    RETVAL_STRINGL(out.c, out.len);
+    smart_string_free(&out);
+}
 
 typedef struct _php_zstd_stream_data {
     char *bufin, *bufout;
@@ -835,13 +1074,6 @@ static int APC_UNSERIALIZER_NAME(zstd)(APC_UNSERIALIZER_ARGS)
 #if PHP_VERSION_ID >= 80000
 #define PHP_ZSTD_OUTPUT_HANDLER_NAME "zstd output compression"
 
-struct _php_zstd_context {
-    ZSTD_CCtx* cctx;
-    ZSTD_CDict *cdict;
-    ZSTD_inBuffer input;
-    ZSTD_outBuffer output;
-};
-
 static int php_zstd_output_encoding(void)
 {
     zval *enc;
@@ -864,13 +1096,6 @@ static int php_zstd_output_encoding(void)
         }
     }
     return PHP_ZSTD_G(compression_coding);
-}
-
-static php_zstd_context* php_zstd_output_handler_context_init(void)
-{
-    php_zstd_context *ctx
-        = (php_zstd_context *) ecalloc(1, sizeof(php_zstd_context));
-    return ctx;
 }
 
 static void
@@ -942,22 +1167,6 @@ static zend_result php_zstd_output_handler_context_start(php_zstd_context *ctx)
     ctx->output.pos = 0;
 
     return SUCCESS;
-}
-
-static void php_zstd_output_handler_context_free(php_zstd_context *ctx)
-{
-    if (ctx->cctx) {
-        ZSTD_freeCCtx(ctx->cctx);
-        ctx->cctx = NULL;
-    }
-    if (ctx->cdict) {
-        ZSTD_freeCDict(ctx->cdict);
-        ctx->cdict = NULL;
-    }
-    if (ctx->output.dst) {
-        efree(ctx->output.dst);
-        ctx->output.dst = NULL;
-    }
 }
 
 static void php_zstd_output_handler_context_dtor(void *opaq)
@@ -1300,6 +1509,18 @@ ZEND_MINIT_FUNCTION(zstd)
 
     php_register_url_stream_wrapper(STREAM_NAME, &php_stream_zstd_wrapper);
 
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "ZstdContext", zstd_context_methods);
+    zstd_context_ptr = zend_register_internal_class_ex(&ce, NULL);
+
+    memcpy(&zstd_context_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    zstd_context_object_handlers.offset = XtOffsetOf(zstd_context_object, zo);
+    zstd_context_object_handlers.free_obj = zstd_context_free_objects_storage;
+    zstd_context_object_handlers.clone_obj = NULL;
+
+    zstd_context_ptr->create_object = zstd_context_objects_new;
+    zstd_context_ptr->default_object_handlers = &zstd_context_object_handlers;
+
 #if defined(HAVE_APCU_SUPPORT)
     apc_register_serializer("zstd",
                             APC_SERIALIZER_NAME(zstd),
@@ -1397,6 +1618,11 @@ static zend_function_entry zstd_functions[] = {
     ZEND_FALIAS(zstd_decompress_usingcdict,
                 zstd_uncompress_dict, arginfo_zstd_uncompress_dict)
 
+    ZEND_FE(zstd_compress_init, arginfo_zstd_compress_init)
+    ZEND_FE(zstd_compress_add, arginfo_zstd_compress_add)
+    ZEND_FE(zstd_uncompress_init, arginfo_zstd_uncompress_init)
+    ZEND_FE(zstd_uncompress_add, arginfo_zstd_uncompress_add)
+
     ZEND_NS_FALIAS(PHP_ZSTD_NS, compress,
                    zstd_compress, arginfo_zstd_compress)
     ZEND_NS_FALIAS(PHP_ZSTD_NS, uncompress,
@@ -1415,6 +1641,15 @@ static zend_function_entry zstd_functions[] = {
                    zstd_uncompress_dict, arginfo_zstd_uncompress_dict)
     ZEND_NS_FALIAS(PHP_ZSTD_NS, decompress_usingcdict,
                    zstd_uncompress_dict, arginfo_zstd_uncompress_dict)
+
+    ZEND_NS_FALIAS(PHP_ZSTD_NS, compress_init,
+                   zstd_compress_init, arginfo_zstd_compress_init)
+    ZEND_NS_FALIAS(PHP_ZSTD_NS, compress_add,
+                   zstd_compress_add, arginfo_zstd_compress_add)
+    ZEND_NS_FALIAS(PHP_ZSTD_NS, uncompress_init,
+                   zstd_uncompress_init, arginfo_zstd_uncompress_init)
+    ZEND_NS_FALIAS(PHP_ZSTD_NS, uncompress_add,
+                   zstd_uncompress_add, arginfo_zstd_uncompress_add)
 
 #if PHP_VERSION_ID >= 80000
     ZEND_FE(ob_zstd_handler, arginfo_ob_zstd_handler)

--- a/zstd.stub.php
+++ b/zstd.stub.php
@@ -2,7 +2,7 @@
 
 namespace {
 
-  class ZstdContext {}
+  final class ZstdContext {}
 
   function zstd_compress(string $data, int $level = 3): string|false {}
 
@@ -12,7 +12,7 @@ namespace {
 
   function zstd_uncompress_dict(string $data, string $dict): string|false {}
 
-  function zstd_compress_init(int $level= 3): ZstdContext|false {}
+  function zstd_compress_init(int $level = 3): ZstdContext|false {}
 
   function zstd_compress_add(ZstdContext $context, string $data, bool $end = false): string|false {}
 
@@ -24,8 +24,6 @@ namespace {
 
 namespace Zstd {
 
-  class ZstdContext {}
-
   function compress(string $data, int $level = 3): string|false {}
 
   function uncompress(string $data): string|false {}
@@ -34,12 +32,12 @@ namespace Zstd {
 
   function uncompress_dict(string $data, string $dict): string|false {}
 
-  function compress_init(int $level= 3): ZstdContext|false {}
+  function compress_init(int $level = 3): \ZstdContext|false {}
 
-  function compress_add(ZstdContext $context, string $data, bool $end = false): string|false {}
+  function compress_add(\ZstdContext $context, string $data, bool $end = false): string|false {}
 
-  function uncompress_init(): ZstdContext|false {}
+  function uncompress_init(): \ZstdContext|false {}
 
-  function uncompress_add(ZstdContext $context, string $data): string|false {}
+  function uncompress_add(\ZstdContext $context, string $data): string|false {}
 
 }

--- a/zstd.stub.php
+++ b/zstd.stub.php
@@ -2,6 +2,8 @@
 
 namespace {
 
+  class ZstdContext {}
+
   function zstd_compress(string $data, int $level = 3): string|false {}
 
   function zstd_uncompress(string $data): string|false {}
@@ -21,6 +23,8 @@ namespace {
 }
 
 namespace Zstd {
+
+  class ZstdContext {}
 
   function compress(string $data, int $level = 3): string|false {}
 

--- a/zstd.stub.php
+++ b/zstd.stub.php
@@ -10,6 +10,14 @@ namespace {
 
   function zstd_uncompress_dict(string $data, string $dict): string|false {}
 
+  function zstd_compress_init(int $level= 3): ZstdContext|false {}
+
+  function zstd_compress_add(ZstdContext $context, string $data, bool $end = false): string|false {}
+
+  function zstd_uncompress_init(): ZstdContext|false {}
+
+  function zstd_uncompress_add(ZstdContext $context, string $data): string|false {}
+
 }
 
 namespace Zstd {
@@ -21,5 +29,13 @@ namespace Zstd {
   function compress_dict(string $data, string $dict, int $level = 3): string|false {}
 
   function uncompress_dict(string $data, string $dict): string|false {}
+
+  function compress_init(int $level= 3): ZstdContext|false {}
+
+  function compress_add(ZstdContext $context, string $data, bool $end = false): string|false {}
+
+  function uncompress_init(): ZstdContext|false {}
+
+  function uncompress_add(ZstdContext $context, string $data): string|false {}
 
 }


### PR DESCRIPTION
Implements feature suggested in #64

* [x] Implementation (using a `ZstdContext` class rather than resources like in #77, see https://wiki.php.net/rfc/resource_to_object_conversion)
* [x] PHPT tests

* * *  

## Example
```php
// compression
$resource = zstd_compress_init();
$compressed = '';
$compressed .= zstd_compress_add($resource, 'Hello, ', false);
$compressed .= zstd_compress_add($resource, 'World!', false);
$compressed .= zstd_compress_add($resource, '', true);

echo zstd_uncompress($compressed), PHP_EOL; // Hello, World!

// uncompression
$resource = zstd_uncompress_init();
$uncompressed = '';
$uncompressed .= zstd_uncompress_add($resource, substr($compressed, 0, 5));
$uncompressed .= zstd_uncompress_add($resource, substr($compressed, 5));

echo $uncompressed, PHP_EOL; // Hello, World!
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced incremental compression and decompression support, allowing data to be processed in chunks using new functions for initializing and updating compression/decompression contexts.
  - Added new functions and namespace aliases for incremental operations, enabling streaming workflows.

- **Documentation**
  - Updated documentation to describe the new incremental compression and decompression functions, including detailed usage, parameters, and return values.

- **Tests**
  - Added comprehensive tests to verify the correctness and consistency of incremental compression and decompression functionality across various chunk sizes and usage scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->