### PR TITLE
use Zend/zend_smart_string.h

### DIFF
--- a/zstd.c
+++ b/zstd.c
@@ -30,7 +30,11 @@
 #include <php_ini.h>
 #include <ext/standard/file.h>
 #include <ext/standard/info.h>
+#if PHP_VERSION_ID < 70200
 #include <ext/standard/php_smart_string.h>
+#else
+#include "Zend/zend_smart_string.h"
+#endif
 #if defined(HAVE_APCU_SUPPORT)
 #include <ext/standard/php_var.h>
 #include <ext/apcu/apc_serializer.h>


### PR DESCRIPTION
* `Zend/zend_smart_string.h` exists since 7.2
* `ext/standard/php_smart_string.h` removed in 8.5.0alpha3