### PR TITLE
Fix a memory leak with zstd_uncompress/zstd_uncompress_dict

### DIFF
--- a/tests/memory_001.phpt
+++ b/tests/memory_001.phpt
@@ -1,0 +1,11 @@
+--TEST--
+memory_usage regression in 0.15.0
+--FILE--
+<?php
+$start = memory_get_usage();
+zstd_uncompress(zstd_compress(str_repeat('a', 1000)));
+$end = memory_get_usage();
+echo ($end - $start) . "\n";
+?>
+--EXPECT--
+0

--- a/zstd.c
+++ b/zstd.c
@@ -527,7 +527,7 @@ ZEND_FUNCTION(zstd_uncompress)
     ctx.input.size = ZSTR_LEN(input);
     ctx.input.pos = 0;
 
-    ctx.output.dst = emalloc(size);
+    ctx.output.dst = erealloc(ctx.output.dst, size);
     ctx.output.size = size;
     ctx.output.pos = 0;
 
@@ -646,7 +646,7 @@ ZEND_FUNCTION(zstd_uncompress_dict)
     ctx.input.size = ZSTR_LEN(input);
     ctx.input.pos = 0;
 
-    ctx.output.dst = emalloc(size);
+    ctx.output.dst = erealloc(ctx.output.dst, size);
     ctx.output.size = size;
     ctx.output.pos = 0;
 


### PR DESCRIPTION
Fixes a memory leak of 128k per zstd_uncompress/zstd_uncompress_dict call (see issue #93)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a memory usage regression during Zstandard decompression, ensuring no net memory growth after a compress/decompress cycle.
  * Improved memory efficiency and stability for Zstandard operations.

* **Tests**
  * Added a regression test that verifies memory usage remains unchanged before and after a Zstandard compress/decompress cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->