### PR TITLE
ci: pin GitHub Action versions to commit SHA

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -52,18 +52,16 @@ jobs:
     steps:
       - name: Prepare required command
         run: |
-          apk upgrade --no-cache
           apk add --no-cache autoconf gcc git libtool make musl-dev
 
-      - name: adding github workspace as safe directory
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          set-safe-directory: true
+          submodules: ${{ ! matrix.library }}
+          token: ${{ github.token }}
 
-      - name: Checkout submodules
-        run: |
-          git submodule update --init --recursive
-        if: ${{ ! matrix.library }}
       - name: Install dependency library
         run: |
           apk add --no-cache zstd-dev

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -11,49 +11,33 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         php:
           - '8.5'
-          - '8.5-zts'
           - '8.4'
-          - '8.4-zts'
           - '8.3'
-          - '8.3-zts'
           - '8.2'
-          - '8.2-zts'
           - '8.1'
-          - '8.1-zts'
+          - '8.0'
+          - '7.4'
+          - '7.3'
+          - '7.2'
+          - '7.1'
+          - '7.0'
+        ts:
+          - nts
+          - zts
         library:
           - ''
           - 'system'
         apcu:
           - ''
           - 'apcu'
-        image: [php]
-        include:
-          - php: '8.0'
-            image: ghcr.io/kjdev/php
-          - php: '7.4'
-            image: ghcr.io/kjdev/php
-          - php: '7.3'
-            image: ghcr.io/kjdev/php
-          - php: '7.2'
-            image: ghcr.io/kjdev/php
-          - php: '7.1'
-            image: ghcr.io/kjdev/php
-          - php: '7.0'
-            image: ghcr.io/kjdev/php
 
     if: contains(github.event.head_commit.message, 'ci skip') == false
 
-    container:
-      image: ${{ matrix.image }}:${{ matrix.php }}-alpine
-
     steps:
-      - name: Prepare required command
-        run: |
-          apk add --no-cache autoconf gcc git libtool make musl-dev
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -62,16 +46,22 @@ jobs:
           submodules: ${{ ! matrix.library }}
           token: ${{ github.token }}
 
+      - name: Setup PHP (${{ matrix.php }} ${{ matrix.ts }})
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: xml, mbstring${{ matrix.apcu != '' && ', apcu' || '' }}
+          coverage: none
+          ini-values: zend.assertions=1
+        env:
+          phpts: ${{ matrix.ts }}
+
       - name: Install dependency library
         run: |
-          apk add --no-cache zstd-dev
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libzstd-dev
         if: ${{ matrix.library }}
-
-      - name: Install PHP APCu extension
-        run: |
-          printf "\n" | pecl install apcu
-          echo 'extension=apcu.so' > $(php --ini | grep 'Scan for' | sed -e 's/"//g' -e 's|.* \(/.*\)$|\1|')/apcu.ini
-        if: ${{ matrix.apcu }}
 
       - name: Build
         run: |
@@ -89,7 +79,7 @@ jobs:
       - name: Test Preparation APCu
         run: |
           cp $(php-config --extension-dir)/apcu.so modules/
-          sed -i 's/\$(PHP_TEST_SHARED_EXTENSIONS)/-d extension=apcu \$(PHP_TEST_SHARED_EXTENSIONS)/' Makefile
+          sed -i 's/\$(PHP_TEST_SHARED_EXTENSIONS)/-d extension=apcu.so \$(PHP_TEST_SHARED_EXTENSIONS)/' Makefile
         if: ${{ matrix.apcu }}
       - name: Test
         run: |

--- a/.github/workflows/submodule.ps1
+++ b/.github/workflows/submodule.ps1
@@ -1,2 +1,0 @@
-
-Invoke-Expression "git submodule update --init --recursive"

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -69,14 +69,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          set-safe-directory: true
+          submodules: ${{ ! matrix.library }}
+          token: ${{ github.token }}
 
-      - name: Checkout submodule
-        run: .\.github\workflows\submodule.ps1
-        shell: pwsh
-        if: ${{ ! matrix.library }}
       - name: Install dependency library
         run: .\.github\workflows\vcpkg.ps1
         shell: pwsh
@@ -84,7 +83,7 @@ jobs:
           VCPKG_LIBRARY: zstd
         if: ${{ matrix.library }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             C:\php\php-*.zip
@@ -118,7 +117,7 @@ jobs:
 
       - if: ${{ github.event_name == 'release' && matrix.library == false && matrix.apcu == '' }}
         name: Store archive DLL
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.PHP_EXT_VERSION }}-${{ matrix.php }}-${{ matrix.ts }}-${{ matrix.vs }}-${{ matrix.arch == 'x64' && 'x86_64' || matrix.arch }}
           path: .\php_${{ env.PHP_EXT }}-${{ env.PHP_EXT_VERSION }}-${{ matrix.php }}-${{ matrix.ts }}-${{ matrix.vs }}-${{ matrix.arch == 'x64' && 'x86_64' || matrix.arch }}.zip
@@ -135,12 +134,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          set-safe-directory: true
+          token: ${{ github.token }}
 
       - name: Get artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows pinned to fixed action revisions for more reproducible runs and safer checkouts.
  * Linux and Windows pipelines unified with a clearer PHP/version/thread-mode matrix and simplified dependency setup.
  * Removed container/image-based execution and redundant submodule initialization to streamline and speed up CI.
  * APCu-related test setup simplified for more reliable extension handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->