### PR TITLE
config.m4: explicit on and off options for APCu

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -27,6 +27,9 @@ PHP_ARG_ENABLE(zstd, whether to enable zstd support,
 PHP_ARG_WITH(libzstd, whether to use system zstd library,
 [  --with-libzstd           Use system zstd library], no, no)
 
+PHP_ARG_ENABLE(apcu, whether to enable APCu support,
+[  --enable-apcu           Enable APCu support], auto, no)
+
 if test "$PHP_ZSTD" != "no"; then
 
   LIBZSTD_MIN_VERSION=1.4.0
@@ -105,13 +108,18 @@ if test "$PHP_ZSTD" != "no"; then
 fi
 
 dnl APCu
-AC_MSG_CHECKING([for APCu includes])
-if test -f "$phpincludedir/ext/apcu/apc_serializer.h"; then
-  apc_inc_path="$phpincludedir"
-  AC_MSG_RESULT([APCu in $apc_inc_path])
-  AC_DEFINE(HAVE_APCU_SUPPORT, 1, [Whether to enable APCu support])
-else
-  AC_MSG_RESULT([not found])
+if test "$PHP_APCU" != "no"; then
+  AC_MSG_CHECKING([for APCu includes])
+  if test -f "$phpincludedir/ext/apcu/apc_serializer.h"; then
+    apc_inc_path="$phpincludedir"
+    AC_MSG_RESULT([APCu in $apc_inc_path])
+    AC_DEFINE(HAVE_APCU_SUPPORT, 1, [Whether to enable APCu support])
+  else
+    if test "$PHP_APCU" != "auto"; then
+      AC_MSG_ERROR([apc_serializer.h header not found])
+    fi
+    AC_MSG_RESULT([not found])
+  fi
 fi
 
 dnl coverage


### PR DESCRIPTION
Hi

I maintain [FreeBSD package](https://www.freshports.org/archivers/php-zstd/) for this and several other compression extensions of yours.

Due to some policy stuff, our system would like to have explicit on and off options for the APCu dependency. But no hurry with a new release, I can patch it locally in our system while waiting for the next one.

Default value "auto" is is the current behaviour, build with APCu if the header happens to be there.

"yes" will fail if the header doesn't exist.

"no" won't even attempt to find the header.

Similar PR to follow to brotli and lz4 too if this gets in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration option added to enable APCu support, with automatic detection enabled by default.
  * Configuration validation enhanced with improved error reporting when required dependencies are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->