### PR TITLE
fix in-tree builds with apcu

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -110,6 +110,9 @@ fi
 dnl APCu
 if test "$PHP_APCU" != "no"; then
   AC_MSG_CHECKING([for APCu includes])
+  if test ! -f "$phpincludedir/ext/apcu/apc_serializer.h" && test -f "$abs_srcdir/ext/apcu/apc_serializer.h"; then
+    phpincludedir="$abs_srcdir"
+  fi
   if test -f "$phpincludedir/ext/apcu/apc_serializer.h"; then
     apc_inc_path="$phpincludedir"
     AC_MSG_RESULT([APCu in $apc_inc_path])

--- a/config.m4
+++ b/config.m4
@@ -105,23 +105,23 @@ if test "$PHP_ZSTD" != "no"; then
   ], [
     PHP_ADD_MAKEFILE_FRAGMENT
   ])
-fi
 
-dnl APCu
-if test "$PHP_APCU" != "no"; then
-  AC_MSG_CHECKING([for APCu includes])
-  if test ! -f "$phpincludedir/ext/apcu/apc_serializer.h" && test -f "$abs_srcdir/ext/apcu/apc_serializer.h"; then
-    phpincludedir="$abs_srcdir"
-  fi
-  if test -f "$phpincludedir/ext/apcu/apc_serializer.h"; then
-    apc_inc_path="$phpincludedir"
-    AC_MSG_RESULT([APCu in $apc_inc_path])
-    AC_DEFINE(HAVE_APCU_SUPPORT, 1, [Whether to enable APCu support])
-  else
-    if test "$PHP_APCU" != "auto"; then
-      AC_MSG_ERROR([apc_serializer.h header not found])
+  dnl APCu
+  if test "$PHP_APCU" != "no"; then
+    AC_MSG_CHECKING([for APCu includes])
+    if test ! -f "$phpincludedir/ext/apcu/apc_serializer.h" && test -f "$abs_srcdir/ext/apcu/apc_serializer.h"; then
+      phpincludedir="$abs_srcdir"
     fi
-    AC_MSG_RESULT([not found])
+    if test -f "$phpincludedir/ext/apcu/apc_serializer.h"; then
+      apc_inc_path="$phpincludedir"
+      AC_MSG_RESULT([APCu in $apc_inc_path])
+      AC_DEFINE(HAVE_APCU_SUPPORT, 1, [Whether to enable APCu support])
+    else
+      if test "$PHP_APCU" != "auto"; then
+        AC_MSG_ERROR([apc_serializer.h header not found])
+      fi
+      AC_MSG_RESULT([not found])
+    fi
   fi
 fi
 


### PR DESCRIPTION
the last commit makes apcu error if the file isn't found in `$phpincludedir/ext/apcu/`, but during in-tree builds the path is `$abssrcdir/ext/apcu/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build detection for APCu so it can find the required headers in more environments.
  * Builds now handle source-tree header locations more reliably, reducing configuration failures and false “not found” messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->