### PR TITLE
Fix compiler warnings

### DIFF
--- a/zstd.c
+++ b/zstd.c
@@ -1402,7 +1402,7 @@ php_zstd_output_handler_load_dict(php_zstd_context *ctx)
 
             PHP_SHA256_CTX context;
             PHP_SHA256Init(&context);
-            PHP_SHA256Update(&context, ZSTR_VAL(data), ZSTR_LEN(data));
+            PHP_SHA256Update(&context, (const unsigned char *)ZSTR_VAL(data), ZSTR_LEN(data));
             PHP_SHA256Final(ctx->dict_digest, &context);
 
             zend_string *b64;

--- a/zstd.c
+++ b/zstd.c
@@ -82,9 +82,6 @@ static zend_always_inline zend_string *smart_str_extract(smart_str *str) {
     UNEXPECTED(ZSTD_isError(result))
 
 zend_class_entry *zstd_context_ptr;
-static const zend_function_entry zstd_context_methods[] = {
-    ZEND_FE_END
-};
 
 struct _php_zstd_context {
     ZSTD_CCtx* cctx;
@@ -777,7 +774,6 @@ ZEND_FUNCTION(zstd_uncompress_init)
 
 ZEND_FUNCTION(zstd_uncompress_add)
 {
-    zend_object *context;
     php_zstd_context *ctx;
     zend_string *input;
     smart_str out = {0};

--- a/zstd.c
+++ b/zstd.c
@@ -42,6 +42,8 @@
 #include <Zend/zend_interfaces.h>
 #include "php_zstd.h"
 
+# pragma GCC diagnostic ignored "-Wunicode"
+
 /* zstd */
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/zstd.c
+++ b/zstd.c
@@ -314,15 +314,6 @@ static zend_class_entry *php_zstd_uncompress_context_register_class(void)
     return class_entry;
 }
 
-static php_zstd_context* php_zstd_output_handler_context_init(void)
-{
-    php_zstd_context *ctx
-        = (php_zstd_context *) ecalloc(1, sizeof(php_zstd_context));
-    ctx->cctx = NULL;
-    ctx->dctx = NULL;
-    return ctx;
-}
-
 #define php_zstd_output_handler_context_free(ctx) php_zstd_context_free(ctx)
 
 /* One-shot functions */
@@ -1266,6 +1257,15 @@ static int APC_UNSERIALIZER_NAME(zstd)(APC_UNSERIALIZER_ARGS)
 #define PHP_ZSTD_ENCODING_ZSTD (1 << 0)
 #define PHP_ZSTD_ENCODING_DCZ (1 << 1)
 
+static php_zstd_context* php_zstd_output_handler_context_init(void)
+{
+    php_zstd_context *ctx
+        = (php_zstd_context *) ecalloc(1, sizeof(php_zstd_context));
+    ctx->cctx = NULL;
+    ctx->dctx = NULL;
+    return ctx;
+}
+
 static int php_zstd_output_encoding(void)
 {
     zval *enc;
@@ -2017,7 +2017,7 @@ static zend_function_entry zstd_functions[] = {
     ZEND_FE(ob_zstd_handler, arginfo_ob_zstd_handler)
 #endif
 
-    {NULL, NULL, NULL}
+    ZEND_FE_END
 };
 
 #if defined(HAVE_APCU_SUPPORT)


### PR DESCRIPTION
LLVM has some things to warn about

```
--- ext/zstd/zstd.lo ---
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/ext/zstd/zstd.c:404:86: warning: \U used with no following hex digits; treating as '\' followed by identifier [-Wunicode]
  404 | ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_zstd_uncompress_init, 0, 0, Zstd\\UnCompress\\Context, MAY_BE_FALSE)
      |                                                                                      ^
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/ext/zstd/zstd.c:414:40: warning: \U used with no following hex digits; treating as '\' followed by identifier [-Wunicode]
  414 |     ZEND_ARG_OBJ_INFO(0, context, Zstd\\UnCompress\\Context, 0)
      |                                        ^
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/ext/zstd/zstd.c:778:18: warning: unused variable 'context' [-Wunused-variable]
  778 |     zend_object *context;
      |                  ^~~~~~~
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/ext/zstd/zstd.c:1403:40: warning: passing 'char[1]' to parameter of type 'const unsigned char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
 1403 |             PHP_SHA256Update(&context, ZSTR_VAL(data), ZSTR_LEN(data));
      |                                        ^~~~~~~~~~~~~~
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/Zend/zend_string.h:68:25: note: expanded from macro 'ZSTR_VAL'
   68 | #define ZSTR_VAL(zstr)  (zstr)->val
      |                         ^~~~~~~~~~~
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/ext/hash/php_hash_sha.h:46:75: note: passing argument to parameter here
   46 | PHP_HASH_API void PHP_SHA256Update(PHP_SHA256_CTX *, const unsigned char *, size_t);
      |                                                                           ^
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/ext/zstd/zstd.c:2022:22: warning: missing field 'num_args' initializer [-Wmissing-field-initializers]
 2022 |     {NULL, NULL, NULL}
      |                      ^
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/ext/zstd/zstd.c:83:34: warning: unused variable 'zstd_context_methods' [-Wunused-const-variable]
   83 | static const zend_function_entry zstd_context_methods[] = {
      |                                  ^~~~~~~~~~~~~~~~~~~~
6 warnings generated.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with compiler warning settings.
  * Corrected dictionary digest validation handling.
  * Updated internal extension registration and cleanup behavior for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->